### PR TITLE
Add a second parameter to STGeomFromText

### DIFF
--- a/lib/CrEOF/Spatial/ORM/Query/AST/Functions/PostgreSql/STGeomFromText.php
+++ b/lib/CrEOF/Spatial/ORM/Query/AST/Functions/PostgreSql/STGeomFromText.php
@@ -39,5 +39,5 @@ class STGeomFromText extends AbstractSpatialDQLFunction
 
     protected $minGeomExpr = 1;
 
-    protected $maxGeomExpr = 1;
+    protected $maxGeomExpr = 2;
 }


### PR DESCRIPTION
The srid parameter avoids getting the error messsage :

    ERROR:  Operation on mixed SRID geometries