### PR TITLE
Remove dependency on doctrine/orm source for tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "doctrine/common": ">=2.1",
         "doctrine/dbal": ">=2.1",
-        "phpunit/phpunit": ">=3.7",
+        "phpunit/phpunit": ">=4.8",
         "ramsey/array_column": "~1.1"
     },
     "autoload": {

--- a/tests/CrEOF/Spatial/Tests/DBAL/Types/GeographyTypeTest.php
+++ b/tests/CrEOF/Spatial/Tests/DBAL/Types/GeographyTypeTest.php
@@ -42,7 +42,7 @@ class GeographyTypeTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('geography');
+        $this->usesEntity('geography');
         parent::setUp();
     }
 
@@ -50,14 +50,14 @@ class GeographyTypeTest extends OrmTest
     {
         $entity = new GeographyEntity();
 
-        $this->_em->persist($entity);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
 
         $id = $entity->getId();
 
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $queryEntity = $this->_em->getRepository(self::GEOGRAPHY_ENTITY)->find($id);
+        $queryEntity = $this->getEntityManager()->getRepository(self::GEOGRAPHY_ENTITY)->find($id);
 
         $this->assertEquals($entity, $queryEntity);
     }
@@ -67,14 +67,14 @@ class GeographyTypeTest extends OrmTest
         $entity = new GeographyEntity();
 
         $entity->setGeography(new Point(1, 1));
-        $this->_em->persist($entity);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
 
         $id = $entity->getId();
 
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $queryEntity = $this->_em->getRepository(self::GEOGRAPHY_ENTITY)->find($id);
+        $queryEntity = $this->getEntityManager()->getRepository(self::GEOGRAPHY_ENTITY)->find($id);
 
         $this->assertEquals($entity, $queryEntity);
     }
@@ -89,14 +89,14 @@ class GeographyTypeTest extends OrmTest
                  new Point(1, 1)
             ))
         );
-        $this->_em->persist($entity);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
 
         $id = $entity->getId();
 
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $queryEntity = $this->_em->getRepository(self::GEOGRAPHY_ENTITY)->find($id);
+        $queryEntity = $this->getEntityManager()->getRepository(self::GEOGRAPHY_ENTITY)->find($id);
 
         $this->assertEquals($entity, $queryEntity);
     }
@@ -116,14 +116,14 @@ class GeographyTypeTest extends OrmTest
         );
 
         $entity->setGeography(new Polygon($rings));
-        $this->_em->persist($entity);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
 
         $id = $entity->getId();
 
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $queryEntity = $this->_em->getRepository(self::GEOGRAPHY_ENTITY)->find($id);
+        $queryEntity = $this->getEntityManager()->getRepository(self::GEOGRAPHY_ENTITY)->find($id);
 
         $this->assertEquals($entity, $queryEntity);
     }

--- a/tests/CrEOF/Spatial/Tests/DBAL/Types/Geometry/LineStringTypeTest.php
+++ b/tests/CrEOF/Spatial/Tests/DBAL/Types/Geometry/LineStringTypeTest.php
@@ -41,7 +41,7 @@ class LineStringTypeTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('linestring');
+        $this->usesEntity('linestring');
         parent::setUp();
     }
 
@@ -49,14 +49,14 @@ class LineStringTypeTest extends OrmTest
     {
         $entity = new LineStringEntity();
 
-        $this->_em->persist($entity);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
 
         $id = $entity->getId();
 
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $queryEntity = $this->_em->getRepository(self::LINESTRING_ENTITY)->find($id);
+        $queryEntity = $this->getEntityManager()->getRepository(self::LINESTRING_ENTITY)->find($id);
 
         $this->assertEquals($entity, $queryEntity);
     }
@@ -72,14 +72,14 @@ class LineStringTypeTest extends OrmTest
         $entity = new LineStringEntity();
 
         $entity->setLineString($lineString);
-        $this->_em->persist($entity);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
 
         $id = $entity->getId();
 
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $queryEntity = $this->_em->getRepository(self::LINESTRING_ENTITY)->find($id);
+        $queryEntity = $this->getEntityManager()->getRepository(self::LINESTRING_ENTITY)->find($id);
 
         $this->assertEquals($entity, $queryEntity);
     }
@@ -95,12 +95,12 @@ class LineStringTypeTest extends OrmTest
         $entity = new LineStringEntity();
 
         $entity->setLineString($lineString);
-        $this->_em->persist($entity);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
 
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $result = $this->_em->getRepository(self::LINESTRING_ENTITY)->findByLineString($lineString);
+        $result = $this->getEntityManager()->getRepository(self::LINESTRING_ENTITY)->findByLineString($lineString);
 
         $this->assertEquals($entity, $result[0]);
     }

--- a/tests/CrEOF/Spatial/Tests/DBAL/Types/Geometry/PointTypeTest.php
+++ b/tests/CrEOF/Spatial/Tests/DBAL/Types/Geometry/PointTypeTest.php
@@ -40,7 +40,7 @@ class PointTypeTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('point');
+        $this->usesEntity('point');
         parent::setUp();
     }
 
@@ -48,14 +48,14 @@ class PointTypeTest extends OrmTest
     {
         $entity = new PointEntity();
 
-        $this->_em->persist($entity);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
 
         $id = $entity->getId();
 
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $queryEntity = $this->_em->getRepository(self::POINT_ENTITY)->find($id);
+        $queryEntity = $this->getEntityManager()->getRepository(self::POINT_ENTITY)->find($id);
 
         $this->assertEquals($entity, $queryEntity);
     }
@@ -66,14 +66,14 @@ class PointTypeTest extends OrmTest
         $entity = new PointEntity();
 
         $entity->setPoint($point);
-        $this->_em->persist($entity);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
 
         $id = $entity->getId();
 
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $queryEntity = $this->_em->getRepository(self::POINT_ENTITY)->find($id);
+        $queryEntity = $this->getEntityManager()->getRepository(self::POINT_ENTITY)->find($id);
 
         $this->assertEquals($entity, $queryEntity);
     }
@@ -84,12 +84,12 @@ class PointTypeTest extends OrmTest
         $entity = new PointEntity();
 
         $entity->setPoint($point);
-        $this->_em->persist($entity);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
 
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $result = $this->_em->getRepository(self::POINT_ENTITY)->findByPoint($point);
+        $result = $this->getEntityManager()->getRepository(self::POINT_ENTITY)->findByPoint($point);
 
         $this->assertEquals($entity, $result[0]);
     }

--- a/tests/CrEOF/Spatial/Tests/DBAL/Types/Geometry/PolygonTypeTest.php
+++ b/tests/CrEOF/Spatial/Tests/DBAL/Types/Geometry/PolygonTypeTest.php
@@ -42,7 +42,7 @@ class PolygonTypeTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('polygon');
+        $this->usesEntity('polygon');
         parent::setUp();
     }
 
@@ -50,14 +50,14 @@ class PolygonTypeTest extends OrmTest
     {
         $entity = new PolygonEntity();
 
-        $this->_em->persist($entity);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
 
         $id = $entity->getId();
 
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $queryEntity = $this->_em->getRepository(self::POLYGON_ENTITY)->find($id);
+        $queryEntity = $this->getEntityManager()->getRepository(self::POLYGON_ENTITY)->find($id);
 
         $this->assertEquals($entity, $queryEntity);
     }
@@ -76,14 +76,14 @@ class PolygonTypeTest extends OrmTest
         $entity = new PolygonEntity();
 
         $entity->setPolygon(new Polygon($rings));
-        $this->_em->persist($entity);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
 
         $id = $entity->getId();
 
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $queryEntity = $this->_em->getRepository(self::POLYGON_ENTITY)->find($id);
+        $queryEntity = $this->getEntityManager()->getRepository(self::POLYGON_ENTITY)->find($id);
 
         $this->assertEquals($entity, $queryEntity);
     }
@@ -109,14 +109,14 @@ class PolygonTypeTest extends OrmTest
         $entity = new PolygonEntity();
 
         $entity->setPolygon(new Polygon($rings));
-        $this->_em->persist($entity);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
 
         $id = $entity->getId();
 
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $queryEntity = $this->_em->getRepository(self::POLYGON_ENTITY)->find($id);
+        $queryEntity = $this->getEntityManager()->getRepository(self::POLYGON_ENTITY)->find($id);
 
         $this->assertEquals($entity, $queryEntity);
     }
@@ -135,11 +135,11 @@ class PolygonTypeTest extends OrmTest
         $entity = new PolygonEntity();
 
         $entity->setPolygon(new Polygon($rings));
-        $this->_em->persist($entity);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $result = $this->_em->getRepository(self::POLYGON_ENTITY)->findByPolygon(new Polygon($rings));
+        $result = $this->getEntityManager()->getRepository(self::POLYGON_ENTITY)->findByPolygon(new Polygon($rings));
 
         $this->assertEquals($entity, $result[0]);
     }

--- a/tests/CrEOF/Spatial/Tests/DBAL/Types/GeometryTypeTest.php
+++ b/tests/CrEOF/Spatial/Tests/DBAL/Types/GeometryTypeTest.php
@@ -43,8 +43,8 @@ class GeometryTypeTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('geometry');
-        $this->useEntity('no_hint_geometry');
+        $this->usesEntity('geometry');
+        $this->usesEntity('no_hint_geometry');
         parent::setUp();
     }
 
@@ -52,14 +52,14 @@ class GeometryTypeTest extends OrmTest
     {
         $entity = new GeometryEntity();
 
-        $this->_em->persist($entity);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
 
         $id = $entity->getId();
 
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $queryEntity = $this->_em->getRepository(self::GEOMETRY_ENTITY)->find($id);
+        $queryEntity = $this->getEntityManager()->getRepository(self::GEOMETRY_ENTITY)->find($id);
 
         $this->assertEquals($entity, $queryEntity);
     }
@@ -69,14 +69,14 @@ class GeometryTypeTest extends OrmTest
         $entity = new GeometryEntity();
 
         $entity->setGeometry(new Point(1, 1));
-        $this->_em->persist($entity);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
 
         $id = $entity->getId();
 
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $queryEntity = $this->_em->getRepository(self::GEOMETRY_ENTITY)->find($id);
+        $queryEntity = $this->getEntityManager()->getRepository(self::GEOMETRY_ENTITY)->find($id);
 
         $this->assertEquals($entity, $queryEntity);
     }
@@ -91,14 +91,14 @@ class GeometryTypeTest extends OrmTest
 
         $point->setSrid(200);
         $entity->setGeometry($point);
-        $this->_em->persist($entity);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
 
         $id = $entity->getId();
 
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $queryEntity = $this->_em->getRepository(self::GEOMETRY_ENTITY)->find($id);
+        $queryEntity = $this->getEntityManager()->getRepository(self::GEOMETRY_ENTITY)->find($id);
 
         $this->assertEquals($entity, $queryEntity);
     }
@@ -113,14 +113,14 @@ class GeometryTypeTest extends OrmTest
 
         $point->setSrid(0);
         $entity->setGeometry($point);
-        $this->_em->persist($entity);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
 
         $id = $entity->getId();
 
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $queryEntity = $this->_em->getRepository(self::GEOMETRY_ENTITY)->find($id);
+        $queryEntity = $this->getEntityManager()->getRepository(self::GEOMETRY_ENTITY)->find($id);
 
         $this->assertEquals($entity, $queryEntity);
     }
@@ -135,14 +135,14 @@ class GeometryTypeTest extends OrmTest
                  new Point(1, 1)
             ))
         );
-        $this->_em->persist($entity);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
 
         $id = $entity->getId();
 
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $queryEntity = $this->_em->getRepository(self::GEOMETRY_ENTITY)->find($id);
+        $queryEntity = $this->getEntityManager()->getRepository(self::GEOMETRY_ENTITY)->find($id);
 
         $this->assertEquals($entity, $queryEntity);
     }
@@ -162,14 +162,14 @@ class GeometryTypeTest extends OrmTest
         );
 
         $entity->setGeometry(new Polygon($rings));
-        $this->_em->persist($entity);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
 
         $id = $entity->getId();
 
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $queryEntity = $this->_em->getRepository(self::GEOMETRY_ENTITY)->find($id);
+        $queryEntity = $this->getEntityManager()->getRepository(self::GEOMETRY_ENTITY)->find($id);
 
         $this->assertEquals($entity, $queryEntity);
     }
@@ -183,7 +183,7 @@ class GeometryTypeTest extends OrmTest
         $entity = new NoHintGeometryEntity();
 
         $entity->setGeometry('POINT(0 0)');
-        $this->_em->persist($entity);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
     }
 }

--- a/tests/CrEOF/Spatial/Tests/DBAL/Types/SchemaTest.php
+++ b/tests/CrEOF/Spatial/Tests/DBAL/Types/SchemaTest.php
@@ -51,7 +51,7 @@ class SchemaTest extends OrmTest
 
     public function testSchemaReverseMapping()
     {
-        $result = $this->_schemaTool->getUpdateSchemaSql($this->getAllClassMetadata(), true);
+        $result = $this->getSchemaTool()->getUpdateSchemaSql($this->getAllClassMetadata(), true);
 
         $this->assertCount(0, $result);
     }
@@ -64,7 +64,7 @@ class SchemaTest extends OrmTest
         $metadata = array();
 
         foreach ($this->getEntityClasses() as $entityClass) {
-            $metadata[] = $this->_em->getClassMetadata($entityClass);
+            $metadata[] = $this->getEntityManager()->getClassMetadata($entityClass);
         }
 
         return $metadata;

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/AreaTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/AreaTest.php
@@ -43,7 +43,7 @@ class AreaTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('polygon');
+        $this->usesEntity('polygon');
         parent::setUp();
     }
 
@@ -64,7 +64,7 @@ class AreaTest extends OrmTest
         );
 
         $entity1->setPolygon(new Polygon($rings1));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
         $rings2 = array(
@@ -85,7 +85,7 @@ class AreaTest extends OrmTest
         );
 
         $entity2->setPolygon(new Polygon($rings2));
-        $this->_em->persist($entity2);
+        $this->getEntityManager()->persist($entity2);
 
         $entity3 = new PolygonEntity();
         $rings3 = array(
@@ -100,7 +100,7 @@ class AreaTest extends OrmTest
         );
 
         $entity3->setPolygon(new Polygon($rings3));
-        $this->_em->persist($entity3);
+        $this->getEntityManager()->persist($entity3);
 
         $entity4 = new PolygonEntity();
         $rings4 = array(
@@ -114,11 +114,11 @@ class AreaTest extends OrmTest
         );
 
         $entity4->setPolygon(new Polygon($rings4));
-        $this->_em->persist($entity4);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity4);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query  = $this->_em->createQuery('SELECT Area(p.polygon) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query  = $this->getEntityManager()->createQuery('SELECT Area(p.polygon) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
         $result = $query->getResult();
 
         $this->assertEquals(100, $result[0][1]);
@@ -144,7 +144,7 @@ class AreaTest extends OrmTest
         );
 
         $entity1->setPolygon(new Polygon($rings1));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
         $rings2 = array(
@@ -165,7 +165,7 @@ class AreaTest extends OrmTest
         );
 
         $entity2->setPolygon(new Polygon($rings2));
-        $this->_em->persist($entity2);
+        $this->getEntityManager()->persist($entity2);
 
         $entity3 = new PolygonEntity();
         $rings3 = array(
@@ -180,7 +180,7 @@ class AreaTest extends OrmTest
         );
 
         $entity3->setPolygon(new Polygon($rings3));
-        $this->_em->persist($entity3);
+        $this->getEntityManager()->persist($entity3);
 
         $entity4 = new PolygonEntity();
         $rings4 = array(
@@ -194,11 +194,11 @@ class AreaTest extends OrmTest
         );
 
         $entity4->setPolygon(new Polygon($rings4));
-        $this->_em->persist($entity4);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity4);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query  = $this->_em->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Area(p.polygon) < 50');
+        $query  = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Area(p.polygon) < 50');
         $result = $query->getResult();
 
         $this->assertCount(1, $result);

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/AsBinaryTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/AsBinaryTest.php
@@ -42,7 +42,7 @@ class AsBinaryTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('linestring');
+        $this->usesEntity('linestring');
         parent::setUp();
     }
 
@@ -64,16 +64,16 @@ class AsBinaryTest extends OrmTest
         $entity1 = new LineStringEntity();
 
         $entity1->setLineString(new LineString($lineString1));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new LineStringEntity();
 
         $entity2->setLineString(new LineString($lineString2));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query   = $this->_em->createQuery('SELECT AsBinary(l.lineString) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $query   = $this->getEntityManager()->createQuery('SELECT AsBinary(l.lineString) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
         $result  = $query->getResult();
         $string1 = '010200000003000000000000000000000000000000000000000000000000000040000000000000004000000000000014400000000000001440';
         $string2 = '0102000000030000000000000000000840000000000000084000000000000010400000000000002e4000000000000014400000000000003640';

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/AsTextTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/AsTextTest.php
@@ -42,7 +42,7 @@ class AsTextTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('linestring');
+        $this->usesEntity('linestring');
         parent::setUp();
     }
 
@@ -64,16 +64,16 @@ class AsTextTest extends OrmTest
         $entity1 = new LineStringEntity();
 
         $entity1->setLineString(new LineString($lineString1));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new LineStringEntity();
 
         $entity2->setLineString(new LineString($lineString2));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT AsText(l.lineString) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $query = $this->getEntityManager()->createQuery('SELECT AsText(l.lineString) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
 
         $result = $query->getResult();
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/ContainsTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/ContainsTest.php
@@ -43,8 +43,8 @@ class ContainsTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('polygon');
-        $this->useType('point');
+        $this->usesEntity('polygon');
+        $this->usesType('point');
         parent::setUp();
     }
 
@@ -70,16 +70,16 @@ class ContainsTest extends OrmTest
         $entity1 = new PolygonEntity();
 
         $entity1->setPolygon(new Polygon(array($lineString1)));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
 
         $entity2->setPolygon(new Polygon(array($lineString2)));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p, Contains(p.polygon, GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, Contains(p.polygon, GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
 
         $query->setParameter('p1', new Point(2, 2), 'point');
 
@@ -114,16 +114,16 @@ class ContainsTest extends OrmTest
         $entity1 = new PolygonEntity();
 
         $entity1->setPolygon(new Polygon(array($lineString1)));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
 
         $entity2->setPolygon(new Polygon(array($lineString1, $lineString2)));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Contains(p.polygon, GeomFromText(:p1)) = 1');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Contains(p.polygon, GeomFromText(:p1)) = 1');
 
         $query->setParameter('p1', new Point(6, 6), 'point');
 
@@ -132,9 +132,9 @@ class ContainsTest extends OrmTest
         $this->assertCount(2, $result);
         $this->assertEquals($entity1, $result[0]);
         $this->assertEquals($entity2, $result[1]);
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Contains(p.polygon, GeomFromText(:p1)) = 1');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Contains(p.polygon, GeomFromText(:p1)) = 1');
 
         $query->setParameter('p1', new Point(2, 2), 'point');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/DisjointTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/DisjointTest.php
@@ -43,7 +43,7 @@ class DisjointTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('polygon');
+        $this->usesEntity('polygon');
         parent::setUp();
     }
 
@@ -77,22 +77,22 @@ class DisjointTest extends OrmTest
         $entity1 = new PolygonEntity();
 
         $entity1->setPolygon(new Polygon(array($lineString1)));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
 
         $entity2->setPolygon(new Polygon(array($lineString2)));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
 
         $entity3 = new PolygonEntity();
 
         $entity3->setPolygon(new Polygon(array($lineString3)));
-        $this->_em->persist($entity3);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity3);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p, Disjoint(p.polygon, GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, Disjoint(p.polygon, GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
 
         $query->setParameter('p1', new Polygon(array($lineString2)), 'polygon');
 
@@ -137,22 +137,22 @@ class DisjointTest extends OrmTest
         $entity1 = new PolygonEntity();
 
         $entity1->setPolygon(new Polygon(array($lineString1)));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
 
         $entity2->setPolygon(new Polygon(array($lineString2)));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
 
         $entity3 = new PolygonEntity();
 
         $entity3->setPolygon(new Polygon(array($lineString3)));
-        $this->_em->persist($entity3);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity3);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Disjoint(p.polygon, GeomFromText(:p1)) = 1');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Disjoint(p.polygon, GeomFromText(:p1)) = 1');
 
         $query->setParameter('p1', new Polygon(array($lineString2)), 'polygon');
 
@@ -160,9 +160,9 @@ class DisjointTest extends OrmTest
 
         $this->assertCount(1, $result);
         $this->assertEquals($entity3, $result[0]);
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Disjoint(p.polygon, GeomFromText(:p1)) = 1');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Disjoint(p.polygon, GeomFromText(:p1)) = 1');
 
         $query->setParameter('p1', new Polygon(array($lineString3)), 'polygon');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/EnvelopeTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/EnvelopeTest.php
@@ -43,7 +43,7 @@ class EnvelopeTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('polygon');
+        $this->usesEntity('polygon');
         parent::setUp();
     }
 
@@ -64,7 +64,7 @@ class EnvelopeTest extends OrmTest
         );
 
         $entity1->setPolygon(new Polygon($rings1));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
         $rings2 = array(
@@ -85,11 +85,11 @@ class EnvelopeTest extends OrmTest
         );
 
         $entity2->setPolygon(new Polygon($rings2));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query  = $this->_em->createQuery('SELECT AsText(Envelope(p.polygon)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query  = $this->getEntityManager()->createQuery('SELECT AsText(Envelope(p.polygon)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
         $result = $query->getResult();
 
         $this->assertEquals('POLYGON((0 0,10 0,10 10,0 10,0 0))', $result[0][1]);
@@ -120,7 +120,7 @@ class EnvelopeTest extends OrmTest
         );
 
         $entity1->setPolygon(new Polygon($rings1));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
         $rings2 = array(
@@ -134,11 +134,11 @@ class EnvelopeTest extends OrmTest
         );
 
         $entity2->setPolygon(new Polygon($rings2));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query        = $this->_em->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Envelope(p.polygon) = GeomFromText(:p1)');
+        $query        = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Envelope(p.polygon) = GeomFromText(:p1)');
         $envelopeRing = new LineString(array(
                 new Point(0, 0),
                 new Point(10, 0),

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/GLengthTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/GLengthTest.php
@@ -42,7 +42,7 @@ class GLengthTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('linestring');
+        $this->usesEntity('linestring');
         parent::setUp();
     }
 
@@ -61,11 +61,11 @@ class GLengthTest extends OrmTest
             ))
         );
 
-        $this->_em->persist($entity);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT l, GLength(l.lineString) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $query = $this->getEntityManager()->createQuery('SELECT l, GLength(l.lineString) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
 
         $result = $query->getResult();
 
@@ -97,11 +97,11 @@ class GLengthTest extends OrmTest
             ))
         );
 
-        $this->_em->persist($entity);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE GLength(GeomFromText(:p1)) > GLength(l.lineString)');
+        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE GLength(GeomFromText(:p1)) > GLength(l.lineString)');
 
         $query->setParameter('p1', $lineString, 'linestring');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/GeomFromTextTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/GeomFromTextTest.php
@@ -42,8 +42,8 @@ class GeomFromTextTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('geometry');
-        $this->useType('point');
+        $this->usesEntity('geometry');
+        $this->usesType('point');
         parent::setUp();
     }
 
@@ -55,11 +55,11 @@ class GeomFromTextTest extends OrmTest
         $entity1 = new GeometryEntity();
 
         $entity1->setGeometry(new Point(5, 5));
-        $this->_em->persist($entity1);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity1);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT g FROM CrEOF\Spatial\Tests\Fixtures\GeometryEntity g WHERE g.geometry = GeomFromText(:geometry)');
+        $query = $this->getEntityManager()->createQuery('SELECT g FROM CrEOF\Spatial\Tests\Fixtures\GeometryEntity g WHERE g.geometry = GeomFromText(:geometry)');
 
         $query->setParameter('geometry', new Point(5, 5), 'point');
 
@@ -83,11 +83,11 @@ class GeomFromTextTest extends OrmTest
         $entity1 = new GeometryEntity();
 
         $entity1->setGeometry(new LineString($value));
-        $this->_em->persist($entity1);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity1);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT g FROM CrEOF\Spatial\Tests\Fixtures\GeometryEntity g WHERE g.geometry = GeomFromText(:geometry)');
+        $query = $this->getEntityManager()->createQuery('SELECT g FROM CrEOF\Spatial\Tests\Fixtures\GeometryEntity g WHERE g.geometry = GeomFromText(:geometry)');
 
         $query->setParameter('geometry', new LineString($value), 'linestring');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/MBRContainsTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/MBRContainsTest.php
@@ -43,8 +43,8 @@ class MBRContainsTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('polygon');
-        $this->useType('point');
+        $this->usesEntity('polygon');
+        $this->usesType('point');
         parent::setUp();
     }
 
@@ -70,16 +70,16 @@ class MBRContainsTest extends OrmTest
         $entity1 = new PolygonEntity();
 
         $entity1->setPolygon(new Polygon(array($lineString1)));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
 
         $entity2->setPolygon(new Polygon(array($lineString2)));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p, MBRContains(p.polygon, GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, MBRContains(p.polygon, GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
 
         $query->setParameter('p1', new Point(2, 2), 'point');
 
@@ -114,16 +114,16 @@ class MBRContainsTest extends OrmTest
         $entity1 = new PolygonEntity();
 
         $entity1->setPolygon(new Polygon(array($lineString1)));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
 
         $entity2->setPolygon(new Polygon(array($lineString1, $lineString2)));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE MBRContains(p.polygon, GeomFromText(:p1)) = 1');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE MBRContains(p.polygon, GeomFromText(:p1)) = 1');
 
         $query->setParameter('p1', new Point(6, 6), 'point');
 
@@ -132,9 +132,9 @@ class MBRContainsTest extends OrmTest
         $this->assertCount(2, $result);
         $this->assertEquals($entity1, $result[0]);
         $this->assertEquals($entity2, $result[1]);
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE MBRContains(p.polygon, GeomFromText(:p1)) = 1');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE MBRContains(p.polygon, GeomFromText(:p1)) = 1');
 
         $query->setParameter('p1', new Point(2, 2), 'point');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/MBRDisjointTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/MBRDisjointTest.php
@@ -43,7 +43,7 @@ class MBRDisjointTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('polygon');
+        $this->usesEntity('polygon');
         parent::setUp();
     }
 
@@ -77,22 +77,22 @@ class MBRDisjointTest extends OrmTest
         $entity1 = new PolygonEntity();
 
         $entity1->setPolygon(new Polygon(array($lineString1)));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
 
         $entity2->setPolygon(new Polygon(array($lineString2)));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
 
         $entity3 = new PolygonEntity();
 
         $entity3->setPolygon(new Polygon(array($lineString3)));
-        $this->_em->persist($entity3);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity3);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p, MBRDisjoint(p.polygon, GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, MBRDisjoint(p.polygon, GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
 
         $query->setParameter('p1', new Polygon(array($lineString2)), 'polygon');
 
@@ -137,22 +137,22 @@ class MBRDisjointTest extends OrmTest
         $entity1 = new PolygonEntity();
 
         $entity1->setPolygon(new Polygon(array($lineString1)));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
 
         $entity2->setPolygon(new Polygon(array($lineString2)));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
 
         $entity3 = new PolygonEntity();
 
         $entity3->setPolygon(new Polygon(array($lineString3)));
-        $this->_em->persist($entity3);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity3);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE MBRDisjoint(p.polygon, GeomFromText(:p1)) = 1');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE MBRDisjoint(p.polygon, GeomFromText(:p1)) = 1');
 
         $query->setParameter('p1', new Polygon(array($lineString2)), 'polygon');
 
@@ -160,9 +160,9 @@ class MBRDisjointTest extends OrmTest
 
         $this->assertCount(1, $result);
         $this->assertEquals($entity3, $result[0]);
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE MBRDisjoint(p.polygon, GeomFromText(:p1)) = 1');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE MBRDisjoint(p.polygon, GeomFromText(:p1)) = 1');
 
         $query->setParameter('p1', new Polygon(array($lineString3)), 'polygon');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/StartPointTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/StartPointTest.php
@@ -42,8 +42,8 @@ class StartPointTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('linestring');
-        $this->useType('point');
+        $this->usesEntity('linestring');
+        $this->usesType('point');
         parent::setUp();
     }
 
@@ -60,11 +60,11 @@ class StartPointTest extends OrmTest
         $entity1 = new LineStringEntity();
 
         $entity1->setLineString($lineString1);
-        $this->_em->persist($entity1);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity1);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT AsText(StartPoint(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $query = $this->getEntityManager()->createQuery('SELECT AsText(StartPoint(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
 
         $result = $query->getResult();
 
@@ -89,16 +89,16 @@ class StartPointTest extends OrmTest
         $entity1 = new LineStringEntity();
 
         $entity1->setLineString($lineString1);
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new LineStringEntity();
 
         $entity2->setLineString($lineString2);
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE StartPoint(l.lineString) = GeomFromText(:p1)');
+        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE StartPoint(l.lineString) = GeomFromText(:p1)');
 
         $query->setParameter('p1', new Point(0, 0), 'point');
 
@@ -126,16 +126,16 @@ class StartPointTest extends OrmTest
         $entity1 = new LineStringEntity();
 
         $entity1->setLineString($lineString1);
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new LineStringEntity();
 
         $entity2->setLineString($lineString2);
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE StartPoint(l.lineString) = StartPoint(GeomFromText(:p1))');
+        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE StartPoint(l.lineString) = StartPoint(GeomFromText(:p1))');
 
         $query->setParameter('p1', $lineString2, 'linestring');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STAreaTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STAreaTest.php
@@ -43,7 +43,7 @@ class STAreaTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('polygon');
+        $this->usesEntity('polygon');
         parent::setUp();
     }
 
@@ -64,7 +64,7 @@ class STAreaTest extends OrmTest
         );
 
         $entity1->setPolygon(new Polygon($rings1));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
         $rings2 = array(
@@ -85,7 +85,7 @@ class STAreaTest extends OrmTest
         );
 
         $entity2->setPolygon(new Polygon($rings2));
-        $this->_em->persist($entity2);
+        $this->getEntityManager()->persist($entity2);
 
         $entity3 = new PolygonEntity();
         $rings3 = array(
@@ -100,7 +100,7 @@ class STAreaTest extends OrmTest
         );
 
         $entity3->setPolygon(new Polygon($rings3));
-        $this->_em->persist($entity3);
+        $this->getEntityManager()->persist($entity3);
 
         $entity4 = new PolygonEntity();
         $rings4 = array(
@@ -114,11 +114,11 @@ class STAreaTest extends OrmTest
         );
 
         $entity4->setPolygon(new Polygon($rings4));
-        $this->_em->persist($entity4);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity4);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query  = $this->_em->createQuery('SELECT ST_Area(p.polygon) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query  = $this->getEntityManager()->createQuery('SELECT ST_Area(p.polygon) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
         $result = $query->getResult();
 
         $this->assertEquals(100, $result[0][1]);
@@ -144,7 +144,7 @@ class STAreaTest extends OrmTest
         );
 
         $entity1->setPolygon(new Polygon($rings1));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
         $rings2 = array(
@@ -165,7 +165,7 @@ class STAreaTest extends OrmTest
         );
 
         $entity2->setPolygon(new Polygon($rings2));
-        $this->_em->persist($entity2);
+        $this->getEntityManager()->persist($entity2);
 
         $entity3 = new PolygonEntity();
         $rings3 = array(
@@ -180,7 +180,7 @@ class STAreaTest extends OrmTest
         );
 
         $entity3->setPolygon(new Polygon($rings3));
-        $this->_em->persist($entity3);
+        $this->getEntityManager()->persist($entity3);
 
         $entity4 = new PolygonEntity();
         $rings4 = array(
@@ -194,11 +194,11 @@ class STAreaTest extends OrmTest
         );
 
         $entity4->setPolygon(new Polygon($rings4));
-        $this->_em->persist($entity4);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity4);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query  = $this->_em->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Area(p.polygon) < 50');
+        $query  = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Area(p.polygon) < 50');
         $result = $query->getResult();
 
         $this->assertCount(1, $result);

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STAsBinaryTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STAsBinaryTest.php
@@ -43,7 +43,7 @@ class STAsBinaryTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('linestring');
+        $this->usesEntity('linestring');
         parent::setUp();
     }
 
@@ -65,16 +65,16 @@ class STAsBinaryTest extends OrmTest
         $entity1 = new LineStringEntity();
 
         $entity1->setLineString(new LineString($lineString1));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new LineStringEntity();
 
         $entity2->setLineString(new LineString($lineString2));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT ST_AsBinary(l.lineString) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $query = $this->getEntityManager()->createQuery('SELECT ST_AsBinary(l.lineString) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
 
         $result = $query->getResult();
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STAsTextTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STAsTextTest.php
@@ -42,7 +42,7 @@ class STAsTextTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('linestring');
+        $this->usesEntity('linestring');
         parent::setUp();
     }
 
@@ -64,16 +64,16 @@ class STAsTextTest extends OrmTest
         $entity1 = new LineStringEntity();
 
         $entity1->setLineString(new LineString($lineString1));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new LineStringEntity();
 
         $entity2->setLineString(new LineString($lineString2));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT ST_AsText(l.lineString) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $query = $this->getEntityManager()->createQuery('SELECT ST_AsText(l.lineString) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
 
         $result = $query->getResult();
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCentroidTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCentroidTest.php
@@ -43,7 +43,7 @@ class STCentroidTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('polygon');
+        $this->usesEntity('polygon');
         parent::setUp();
     }
 
@@ -69,16 +69,16 @@ class STCentroidTest extends OrmTest
         $entity1 = new PolygonEntity();
 
         $entity1->setPolygon(new Polygon(array($lineString1)));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
 
         $entity2->setPolygon(new Polygon(array($lineString2)));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p, ST_AsText(ST_Centroid(p.polygon)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, ST_AsText(ST_Centroid(p.polygon)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
 
         $result = $query->getResult();
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STClosestPointTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STClosestPointTest.php
@@ -43,8 +43,8 @@ class STClosestPointTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('polygon');
-        $this->useType('point');
+        $this->usesEntity('polygon');
+        $this->usesType('point');
         parent::setUp();
     }
 
@@ -70,16 +70,16 @@ class STClosestPointTest extends OrmTest
         $entity1 = new PolygonEntity();
 
         $entity1->setPolygon(new Polygon(array($ring1)));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
 
         $entity2->setPolygon(new Polygon(array($ring2)));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p, ST_AsText(ST_ClosestPoint(p.polygon, ST_GeomFromText(:p1))) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, ST_AsText(ST_ClosestPoint(p.polygon, ST_GeomFromText(:p1))) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
 
         $query->setParameter('p1', new Point(2, 2), 'point');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STContainsProperlyTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STContainsProperlyTest.php
@@ -43,7 +43,7 @@ class STContainsProperlyTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('polygon');
+        $this->usesEntity('polygon');
         parent::setUp();
     }
 
@@ -69,16 +69,16 @@ class STContainsProperlyTest extends OrmTest
         $entity1 = new PolygonEntity();
 
         $entity1->setPolygon(new Polygon(array($lineString1)));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
 
         $entity2->setPolygon(new Polygon(array($lineString2)));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p, ST_ContainsProperly(p.polygon, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, ST_ContainsProperly(p.polygon, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
 
         $query->setParameter('p1', $lineString2, 'linestring');
 
@@ -113,16 +113,16 @@ class STContainsProperlyTest extends OrmTest
         $entity1 = new PolygonEntity();
 
         $entity1->setPolygon(new Polygon(array($lineString1)));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
 
         $entity2->setPolygon(new Polygon(array($lineString2)));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_ContainsProperly(p.polygon, ST_GeomFromText(:p1)) = true');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_ContainsProperly(p.polygon, ST_GeomFromText(:p1)) = true');
 
         $query->setParameter('p1', $lineString2, 'linestring');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STContainsTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STContainsTest.php
@@ -43,8 +43,8 @@ class STContainsTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('polygon');
-        $this->useType('point');
+        $this->usesEntity('polygon');
+        $this->usesType('point');
         parent::setUp();
     }
 
@@ -70,16 +70,16 @@ class STContainsTest extends OrmTest
         $entity1 = new PolygonEntity();
 
         $entity1->setPolygon(new Polygon(array($lineString1)));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
 
         $entity2->setPolygon(new Polygon(array($lineString2)));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p, ST_Contains(p.polygon, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, ST_Contains(p.polygon, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
 
         $query->setParameter('p1', new Point(2, 2), 'point');
 
@@ -114,16 +114,16 @@ class STContainsTest extends OrmTest
         $entity1 = new PolygonEntity();
 
         $entity1->setPolygon(new Polygon(array($lineString1)));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
 
         $entity2->setPolygon(new Polygon(array($lineString1, $lineString2)));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Contains(p.polygon, ST_GeomFromText(:p1)) = true');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Contains(p.polygon, ST_GeomFromText(:p1)) = true');
 
         $query->setParameter('p1', new Point(6, 6), 'point');
 
@@ -131,9 +131,9 @@ class STContainsTest extends OrmTest
 
         $this->assertCount(1, $result);
         $this->assertEquals($entity1, $result[0]);
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Contains(p.polygon, ST_GeomFromText(:p1)) = true');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Contains(p.polygon, ST_GeomFromText(:p1)) = true');
 
         $query->setParameter('p1', new Point(2, 2), 'point');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCoveredByTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCoveredByTest.php
@@ -43,7 +43,7 @@ class STCoveredByTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('polygon');
+        $this->usesEntity('polygon');
         parent::setUp();
     }
 
@@ -69,16 +69,16 @@ class STCoveredByTest extends OrmTest
         $entity1 = new PolygonEntity();
 
         $entity1->setPolygon(new Polygon(array($lineString1)));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
 
         $entity2->setPolygon(new Polygon(array($lineString2)));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p, ST_CoveredBy(p.polygon, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, ST_CoveredBy(p.polygon, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
 
         $query->setParameter('p1', new Polygon(array($lineString2)), 'polygon');
 
@@ -113,16 +113,16 @@ class STCoveredByTest extends OrmTest
         $entity1 = new PolygonEntity();
 
         $entity1->setPolygon(new Polygon(array($lineString1)));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
 
         $entity2->setPolygon(new Polygon(array($lineString2)));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_CoveredBy(p.polygon, ST_GeomFromText(:p1)) = true');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_CoveredBy(p.polygon, ST_GeomFromText(:p1)) = true');
 
         $query->setParameter('p1', new Polygon(array($lineString2)), 'polygon');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCoversTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCoversTest.php
@@ -43,7 +43,7 @@ class STCoversTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('polygon');
+        $this->usesEntity('polygon');
         parent::setUp();
     }
 
@@ -69,16 +69,16 @@ class STCoversTest extends OrmTest
         $entity1 = new PolygonEntity();
 
         $entity1->setPolygon(new Polygon(array($lineString1)));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
 
         $entity2->setPolygon(new Polygon(array($lineString2)));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p, ST_Covers(p.polygon, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, ST_Covers(p.polygon, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
 
         $query->setParameter('p1', new Polygon(array($lineString2)), 'polygon');
 
@@ -113,16 +113,16 @@ class STCoversTest extends OrmTest
         $entity1 = new PolygonEntity();
 
         $entity1->setPolygon(new Polygon(array($lineString1)));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
 
         $entity2->setPolygon(new Polygon(array($lineString2)));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Covers(p.polygon, ST_GeomFromText(:p1)) = true');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Covers(p.polygon, ST_GeomFromText(:p1)) = true');
 
         $query->setParameter('p1', new Polygon(array($lineString2)), 'polygon');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCrossesTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCrossesTest.php
@@ -42,7 +42,7 @@ class STCrossesTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('linestring');
+        $this->usesEntity('linestring');
         parent::setUp();
     }
 
@@ -67,21 +67,21 @@ class STCrossesTest extends OrmTest
         $entity1 = new LineStringEntity();
 
         $entity1->setLineString($lineString1);
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 =  new LineStringEntity();
 
         $entity2->setLineString($lineString2);
-        $this->_em->persist($entity2);
+        $this->getEntityManager()->persist($entity2);
 
         $entity3 =  new LineStringEntity();
 
         $entity3->setLineString($lineString3);
-        $this->_em->persist($entity3);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity3);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT l, ST_Crosses(l.lineString, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $query = $this->getEntityManager()->createQuery('SELECT l, ST_Crosses(l.lineString, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
 
         $query->setParameter('p1', $lineString1, 'linestring');
 
@@ -117,21 +117,21 @@ class STCrossesTest extends OrmTest
         $entity1 = new LineStringEntity();
 
         $entity1->setLineString($lineString1);
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 =  new LineStringEntity();
 
         $entity2->setLineString($lineString2);
-        $this->_em->persist($entity2);
+        $this->getEntityManager()->persist($entity2);
 
         $entity3 =  new LineStringEntity();
 
         $entity3->setLineString($lineString3);
-        $this->_em->persist($entity3);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity3);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_Crosses(l.lineString, ST_GeomFromText(:p1)) = true');
+        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_Crosses(l.lineString, ST_GeomFromText(:p1)) = true');
 
         $query->setParameter('p1', $lineString1, 'linestring');
 
@@ -139,9 +139,9 @@ class STCrossesTest extends OrmTest
 
         $this->assertCount(1, $result);
         $this->assertEquals($entity2, $result[0]);
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_Crosses(l.lineString, ST_GeomFromText(:p1)) = true');
+        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_Crosses(l.lineString, ST_GeomFromText(:p1)) = true');
 
         $query->setParameter('p1', $lineString3, 'linestring');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STDisjointTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STDisjointTest.php
@@ -43,7 +43,7 @@ class STDisjointTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('polygon');
+        $this->usesEntity('polygon');
         parent::setUp();
     }
 
@@ -77,22 +77,22 @@ class STDisjointTest extends OrmTest
         $entity1 = new PolygonEntity();
 
         $entity1->setPolygon(new Polygon(array($lineString1)));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
 
         $entity2->setPolygon(new Polygon(array($lineString2)));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
 
         $entity3 = new PolygonEntity();
 
         $entity3->setPolygon(new Polygon(array($lineString3)));
-        $this->_em->persist($entity3);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity3);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p, ST_Disjoint(p.polygon, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, ST_Disjoint(p.polygon, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
 
         $query->setParameter('p1', new Polygon(array($lineString2)), 'polygon');
 
@@ -137,22 +137,22 @@ class STDisjointTest extends OrmTest
         $entity1 = new PolygonEntity();
 
         $entity1->setPolygon(new Polygon(array($lineString1)));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
 
         $entity2->setPolygon(new Polygon(array($lineString2)));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
 
         $entity3 = new PolygonEntity();
 
         $entity3->setPolygon(new Polygon(array($lineString3)));
-        $this->_em->persist($entity3);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity3);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Disjoint(p.polygon, ST_GeomFromText(:p1)) = true');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Disjoint(p.polygon, ST_GeomFromText(:p1)) = true');
 
         $query->setParameter('p1', new Polygon(array($lineString2)), 'polygon');
 
@@ -160,9 +160,9 @@ class STDisjointTest extends OrmTest
 
         $this->assertCount(1, $result);
         $this->assertEquals($entity3, $result[0]);
-        $this->_em->clear();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Disjoint(p.polygon, ST_GeomFromText(:p1)) = true');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Disjoint(p.polygon, ST_GeomFromText(:p1)) = true');
 
         $query->setParameter('p1', new Polygon(array($lineString3)), 'polygon');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STDistanceSphereTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STDistanceSphereTest.php
@@ -43,7 +43,7 @@ class STDistanceSphereTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('point');
+        $this->usesEntity('point');
         parent::setUp();
     }
 
@@ -60,21 +60,21 @@ class STDistanceSphereTest extends OrmTest
         $entity1 = new PointEntity();
 
         $entity1->setPoint($newYork);
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PointEntity();
 
         $entity2->setPoint($losAngles);
-        $this->_em->persist($entity2);
+        $this->getEntityManager()->persist($entity2);
 
         $entity3 = new PointEntity();
 
         $entity3->setPoint($dallas);
-        $this->_em->persist($entity3);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity3);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p, ST_Distance_Sphere(p.point, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PointEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, ST_Distance_Sphere(p.point, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PointEntity p');
 
         $query->setParameter('p1', $madison, 'point');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STDistanceTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STDistanceTest.php
@@ -43,9 +43,9 @@ class STDistanceTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('point');
-        $this->useEntity('geography');
-        $this->useType('geopoint');
+        $this->usesEntity('point');
+        $this->usesEntity('geography');
+        $this->usesType('geopoint');
         parent::setUp();
     }
 
@@ -62,21 +62,21 @@ class STDistanceTest extends OrmTest
         $entity1 = new PointEntity();
 
         $entity1->setPoint($newYork);
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PointEntity();
 
         $entity2->setPoint($losAngles);
-        $this->_em->persist($entity2);
+        $this->getEntityManager()->persist($entity2);
 
         $entity3 = new PointEntity();
 
         $entity3->setPoint($dallas);
-        $this->_em->persist($entity3);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity3);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT p, ST_Distance(p.point, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PointEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, ST_Distance(p.point, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PointEntity p');
 
         $query->setParameter('p1', $madison, 'point');
 
@@ -104,21 +104,21 @@ class STDistanceTest extends OrmTest
         $entity1 = new GeographyEntity();
 
         $entity1->setGeography($newYork);
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new GeographyEntity();
 
         $entity2->setGeography($losAngles);
-        $this->_em->persist($entity2);
+        $this->getEntityManager()->persist($entity2);
 
         $entity3 = new GeographyEntity();
 
         $entity3->setGeography($dallas);
-        $this->_em->persist($entity3);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity3);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT g, ST_Distance(g.geography, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\GeographyEntity g');
+        $query = $this->getEntityManager()->createQuery('SELECT g, ST_Distance(g.geography, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\GeographyEntity g');
 
         $query->setParameter('p1', $madison, 'geopoint');
 
@@ -146,21 +146,21 @@ class STDistanceTest extends OrmTest
         $entity1 = new GeographyEntity();
 
         $entity1->setGeography($newYork);
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new GeographyEntity();
 
         $entity2->setGeography($losAngles);
-        $this->_em->persist($entity2);
+        $this->getEntityManager()->persist($entity2);
 
         $entity3 = new GeographyEntity();
 
         $entity3->setGeography($dallas);
-        $this->_em->persist($entity3);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity3);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT g, ST_Distance(g.geography, ST_GeomFromText(:p1), false) FROM CrEOF\Spatial\Tests\Fixtures\GeographyEntity g');
+        $query = $this->getEntityManager()->createQuery('SELECT g, ST_Distance(g.geography, ST_GeomFromText(:p1), false) FROM CrEOF\Spatial\Tests\Fixtures\GeographyEntity g');
 
         $query->setParameter('p1', $madison, 'geopoint');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STEnvelopeTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STEnvelopeTest.php
@@ -43,7 +43,7 @@ class STEnvelopeTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('polygon');
+        $this->usesEntity('polygon');
         parent::setUp();
     }
 
@@ -64,7 +64,7 @@ class STEnvelopeTest extends OrmTest
         );
 
         $entity1->setPolygon(new Polygon($rings1));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
         $rings2 = array(
@@ -85,11 +85,11 @@ class STEnvelopeTest extends OrmTest
         );
 
         $entity2->setPolygon(new Polygon($rings2));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query  = $this->_em->createQuery('SELECT ST_AsText(ST_Envelope(p.polygon)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query  = $this->getEntityManager()->createQuery('SELECT ST_AsText(ST_Envelope(p.polygon)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
         $result = $query->getResult();
 
         $this->assertEquals('POLYGON((0 0,0 10,10 10,10 0,0 0))', $result[0][1]);
@@ -120,7 +120,7 @@ class STEnvelopeTest extends OrmTest
         );
 
         $entity1->setPolygon(new Polygon($rings1));
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new PolygonEntity();
         $rings2 = array(
@@ -134,11 +134,11 @@ class STEnvelopeTest extends OrmTest
         );
 
         $entity2->setPolygon(new Polygon($rings2));
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query        = $this->_em->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Envelope(p.polygon) = ST_GeomFromText(:p1)');
+        $query        = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Envelope(p.polygon) = ST_GeomFromText(:p1)');
         $envelopeRing = new LineString(array(
                 new Point(0, 0),
                 new Point(10, 0),

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STGeomFromTextTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STGeomFromTextTest.php
@@ -42,7 +42,7 @@ class STGeomFromTextTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('geometry');
+        $this->usesEntity('geometry');
         parent::setUp();
     }
 
@@ -54,11 +54,11 @@ class STGeomFromTextTest extends OrmTest
         $entity1 = new GeometryEntity();
 
         $entity1->setGeometry(new Point(5, 5));
-        $this->_em->persist($entity1);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity1);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT g FROM CrEOF\Spatial\Tests\Fixtures\GeometryEntity g WHERE g.geometry = ST_GeomFromText(:geometry)');
+        $query = $this->getEntityManager()->createQuery('SELECT g FROM CrEOF\Spatial\Tests\Fixtures\GeometryEntity g WHERE g.geometry = ST_GeomFromText(:geometry)');
 
         $query->setParameter('geometry', new Point(5, 5), 'point');
 
@@ -82,11 +82,11 @@ class STGeomFromTextTest extends OrmTest
         $entity1 = new GeometryEntity();
 
         $entity1->setGeometry(new LineString($value));
-        $this->_em->persist($entity1);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity1);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT g FROM CrEOF\Spatial\Tests\Fixtures\GeometryEntity g WHERE g.geometry = ST_GeomFromText(:geometry)');
+        $query = $this->getEntityManager()->createQuery('SELECT g FROM CrEOF\Spatial\Tests\Fixtures\GeometryEntity g WHERE g.geometry = ST_GeomFromText(:geometry)');
 
         $query->setParameter('geometry', new LineString($value), 'linestring');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STLengthTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STLengthTest.php
@@ -42,7 +42,7 @@ class STLengthTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('linestring');
+        $this->usesEntity('linestring');
         parent::setUp();
     }
 
@@ -61,11 +61,11 @@ class STLengthTest extends OrmTest
             ))
         );
 
-        $this->_em->persist($entity);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT l, ST_Length(l.lineString) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $query = $this->getEntityManager()->createQuery('SELECT l, ST_Length(l.lineString) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
 
         $result = $query->getResult();
 
@@ -95,11 +95,11 @@ class STLengthTest extends OrmTest
             ))
         );
 
-        $this->_em->persist($entity);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_Length(ST_GeomFromText(:p1)) > ST_Length(l.lineString)');
+        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_Length(ST_GeomFromText(:p1)) > ST_Length(l.lineString)');
 
         $query->setParameter('p1', $lineString, 'linestring');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STLineCrossingDirectionTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STLineCrossingDirectionTest.php
@@ -42,7 +42,7 @@ class STLineCrossingDirectionTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('linestring');
+        $this->usesEntity('linestring');
         parent::setUp();
     }
 
@@ -76,21 +76,21 @@ class STLineCrossingDirectionTest extends OrmTest
         $entity1 = new LineStringEntity();
 
         $entity1->setLineString($lineString1);
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 =  new LineStringEntity();
 
         $entity2->setLineString($lineString2);
-        $this->_em->persist($entity2);
+        $this->getEntityManager()->persist($entity2);
 
         $entity3 =  new LineStringEntity();
 
         $entity3->setLineString($lineString3);
-        $this->_em->persist($entity3);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity3);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT l, ST_LineCrossingDirection(l.lineString, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $query = $this->getEntityManager()->createQuery('SELECT l, ST_LineCrossingDirection(l.lineString, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
 
         $query->setParameter('p1', $lineString4, 'linestring');
 
@@ -135,21 +135,21 @@ class STLineCrossingDirectionTest extends OrmTest
         $entity1 = new LineStringEntity();
 
         $entity1->setLineString($lineString1);
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 =  new LineStringEntity();
 
         $entity2->setLineString($lineString2);
-        $this->_em->persist($entity2);
+        $this->getEntityManager()->persist($entity2);
 
         $entity3 =  new LineStringEntity();
 
         $entity3->setLineString($lineString3);
-        $this->_em->persist($entity3);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity3);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_LineCrossingDirection(l.lineString, ST_GeomFromText(:p1)) = 1');
+        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_LineCrossingDirection(l.lineString, ST_GeomFromText(:p1)) = 1');
 
         $query->setParameter('p1', $lineString4, 'linestring');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STStartPointTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STStartPointTest.php
@@ -42,7 +42,7 @@ class STStartPointTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('linestring');
+        $this->usesEntity('linestring');
         parent::setUp();
     }
 
@@ -59,11 +59,11 @@ class STStartPointTest extends OrmTest
         $entity1 = new LineStringEntity();
 
         $entity1->setLineString($lineString1);
-        $this->_em->persist($entity1);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity1);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT ST_AsText(ST_StartPoint(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $query = $this->getEntityManager()->createQuery('SELECT ST_AsText(ST_StartPoint(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
 
         $result = $query->getResult();
 
@@ -88,16 +88,16 @@ class STStartPointTest extends OrmTest
         $entity1 = new LineStringEntity();
 
         $entity1->setLineString($lineString1);
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new LineStringEntity();
 
         $entity2->setLineString($lineString2);
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_StartPoint(l.lineString) = ST_GeomFromText(:p1)');
+        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_StartPoint(l.lineString) = ST_GeomFromText(:p1)');
 
         $query->setParameter('p1', new Point(0, 0), 'point');
 
@@ -125,16 +125,16 @@ class STStartPointTest extends OrmTest
         $entity1 = new LineStringEntity();
 
         $entity1->setLineString($lineString1);
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new LineStringEntity();
 
         $entity2->setLineString($lineString2);
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_StartPoint(l.lineString) = ST_StartPoint(ST_GeomFromText(:p1))');
+        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_StartPoint(l.lineString) = ST_StartPoint(ST_GeomFromText(:p1))');
 
         $query->setParameter('p1', $lineString2, 'linestring');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STSummarayTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STSummarayTest.php
@@ -47,8 +47,8 @@ class STSummaryTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('geometry');
-        $this->useEntity('geography');
+        $this->usesEntity('geometry');
+        $this->usesEntity('geography');
         parent::setUp();
     }
 
@@ -61,7 +61,7 @@ class STSummaryTest extends OrmTest
         $point1  = new Point(5, 5);
 
         $entity1->setGeometry($point1);
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2     = new GeometryEntity();
         $lineString2 = new LineString(
@@ -73,7 +73,7 @@ class STSummaryTest extends OrmTest
         );
 
         $entity2->setGeometry($lineString2);
-        $this->_em->persist($entity2);
+        $this->getEntityManager()->persist($entity2);
 
         $entity3  = new GeometryEntity();
         $polygon3 = new Polygon(
@@ -89,11 +89,11 @@ class STSummaryTest extends OrmTest
         );
 
         $entity3->setGeometry($polygon3);
-        $this->_em->persist($entity3);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity3);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query  = $this->_em->createQuery('SELECT g, ST_Summary(g.geometry) FROM CrEOF\Spatial\Tests\Fixtures\GeometryEntity g');
+        $query  = $this->getEntityManager()->createQuery('SELECT g, ST_Summary(g.geometry) FROM CrEOF\Spatial\Tests\Fixtures\GeometryEntity g');
         $result = $query->getResult();
 
         $this->assertCount(3, $result);
@@ -114,7 +114,7 @@ class STSummaryTest extends OrmTest
         $point1  = new GeographyPoint(5, 5);
 
         $entity1->setGeography($point1);
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2     = new GeographyEntity();
         $lineString2 = new GeographyLineString(
@@ -126,7 +126,7 @@ class STSummaryTest extends OrmTest
         );
 
         $entity2->setGeography($lineString2);
-        $this->_em->persist($entity2);
+        $this->getEntityManager()->persist($entity2);
 
         $entity3  = new GeographyEntity();
         $polygon3 = new GeographyPolygon(
@@ -142,11 +142,11 @@ class STSummaryTest extends OrmTest
         );
 
         $entity3->setGeography($polygon3);
-        $this->_em->persist($entity3);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity3);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query  = $this->_em->createQuery('SELECT g, ST_Summary(g.geography) FROM CrEOF\Spatial\Tests\Fixtures\GeographyEntity g');
+        $query  = $this->getEntityManager()->createQuery('SELECT g, ST_Summary(g.geography) FROM CrEOF\Spatial\Tests\Fixtures\GeographyEntity g');
         $result = $query->getResult();
 
         $this->assertCount(3, $result);

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/GeometryWalkerTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/GeometryWalkerTest.php
@@ -41,7 +41,7 @@ class GeometryWalkerTest extends OrmTest
 {
     protected function setUp()
     {
-        $this->useEntity('linestring');
+        $this->usesEntity('linestring');
         parent::setUp();
     }
 
@@ -64,23 +64,23 @@ class GeometryWalkerTest extends OrmTest
         $entity1 = new LineStringEntity();
 
         $entity1->setLineString($lineString1);
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new LineStringEntity();
 
         $entity2->setLineString($lineString2);
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT AsBinary(StartPoint(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $query = $this->getEntityManager()->createQuery('SELECT AsBinary(StartPoint(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'CrEOF\Spatial\ORM\Query\GeometryWalker');
 
         $result = $query->getResult();
         $this->assertEquals(new Point(0, 0), $result[0][1]);
         $this->assertEquals(new Point(3, 3), $result[1][1]);
 
-        $query = $this->_em->createQuery('SELECT AsBinary(Envelope(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $query = $this->getEntityManager()->createQuery('SELECT AsBinary(Envelope(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'CrEOF\Spatial\ORM\Query\GeometryWalker');
 
         $result = $query->getResult();
@@ -107,23 +107,23 @@ class GeometryWalkerTest extends OrmTest
         $entity1 = new LineStringEntity();
 
         $entity1->setLineString($lineString1);
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new LineStringEntity();
 
         $entity2->setLineString($lineString2);
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT ST_AsBinary(ST_StartPoint(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $query = $this->getEntityManager()->createQuery('SELECT ST_AsBinary(ST_StartPoint(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'CrEOF\Spatial\ORM\Query\GeometryWalker');
 
         $result = $query->getResult();
         $this->assertEquals(new Point(0, 0), $result[0][1]);
         $this->assertEquals(new Point(3, 3), $result[1][1]);
 
-        $query = $this->_em->createQuery('SELECT ST_AsBinary(ST_Envelope(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $query = $this->getEntityManager()->createQuery('SELECT ST_AsBinary(ST_Envelope(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'CrEOF\Spatial\ORM\Query\GeometryWalker');
 
         $result = $query->getResult();
@@ -150,23 +150,23 @@ class GeometryWalkerTest extends OrmTest
         $entity1 = new LineStringEntity();
 
         $entity1->setLineString($lineString1);
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new LineStringEntity();
 
         $entity2->setLineString($lineString2);
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT AsText(StartPoint(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $query = $this->getEntityManager()->createQuery('SELECT AsText(StartPoint(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'CrEOF\Spatial\ORM\Query\GeometryWalker');
 
         $result = $query->getResult();
         $this->assertEquals(new Point(0, 0), $result[0][1]);
         $this->assertEquals(new Point(3, 3), $result[1][1]);
 
-        $query = $this->_em->createQuery('SELECT AsText(Envelope(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $query = $this->getEntityManager()->createQuery('SELECT AsText(Envelope(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'CrEOF\Spatial\ORM\Query\GeometryWalker');
 
         $result = $query->getResult();
@@ -193,23 +193,23 @@ class GeometryWalkerTest extends OrmTest
         $entity1 = new LineStringEntity();
 
         $entity1->setLineString($lineString1);
-        $this->_em->persist($entity1);
+        $this->getEntityManager()->persist($entity1);
 
         $entity2 = new LineStringEntity();
 
         $entity2->setLineString($lineString2);
-        $this->_em->persist($entity2);
-        $this->_em->flush();
-        $this->_em->clear();
+        $this->getEntityManager()->persist($entity2);
+        $this->getEntityManager()->flush();
+        $this->getEntityManager()->clear();
 
-        $query = $this->_em->createQuery('SELECT ST_AsText(ST_StartPoint(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $query = $this->getEntityManager()->createQuery('SELECT ST_AsText(ST_StartPoint(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'CrEOF\Spatial\ORM\Query\GeometryWalker');
 
         $result = $query->getResult();
         $this->assertEquals(new Point(0, 0), $result[0][1]);
         $this->assertEquals(new Point(3, 3), $result[1][1]);
 
-        $query = $this->_em->createQuery('SELECT ST_AsText(ST_Envelope(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $query = $this->getEntityManager()->createQuery('SELECT ST_AsText(ST_Envelope(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'CrEOF\Spatial\ORM\Query\GeometryWalker');
 
         $result = $query->getResult();


### PR DESCRIPTION
OrmTest no longer extends from doctrine/orm. Replace property access in tests with getters.

Tests still failing with Doctrine 2.5, next on the list.