### PR TITLE
uniform ST class names in mysql, ensuring doctrine can resolve them

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -107,15 +107,15 @@ Add the types and functions you need to your Symfony configuration. The doctrine
                         point:                  CrEOF\Spatial\ORM\Query\AST\Functions\MySql\Point
                         srid:                   CrEOF\Spatial\ORM\Query\AST\Functions\MySql\SRID
                         startpoint:             CrEOF\Spatial\ORM\Query\AST\Functions\MySql\StartPoint
-                        st_buffer:              CrEOF\Spatial\ORM\Query\AST\Functions\MySql\ST_Buffer
-                        st_contains:            CrEOF\Spatial\ORM\Query\AST\Functions\MySql\ST_Contains
-                        st_crosses:             CrEOF\Spatial\ORM\Query\AST\Functions\MySql\ST_Crosses
-                        st_disjoint:            CrEOF\Spatial\ORM\Query\AST\Functions\MySql\ST_Disjoint
-                        st_equals:              CrEOF\Spatial\ORM\Query\AST\Functions\MySql\ST_Equals
-                        st_intersects:          CrEOF\Spatial\ORM\Query\AST\Functions\MySql\ST_Intersects
-                        st_overlaps:            CrEOF\Spatial\ORM\Query\AST\Functions\MySql\ST_Overlaps
-                        st_touches:             CrEOF\Spatial\ORM\Query\AST\Functions\MySql\ST_Touches
-                        st_within:              CrEOF\Spatial\ORM\Query\AST\Functions\MySql\ST_Within
+                        st_buffer:              CrEOF\Spatial\ORM\Query\AST\Functions\MySql\STBuffer
+                        st_contains:            CrEOF\Spatial\ORM\Query\AST\Functions\MySql\STContains
+                        st_crosses:             CrEOF\Spatial\ORM\Query\AST\Functions\MySql\STCrosses
+                        st_disjoint:            CrEOF\Spatial\ORM\Query\AST\Functions\MySql\STDisjoint
+                        st_equals:              CrEOF\Spatial\ORM\Query\AST\Functions\MySql\STEquals
+                        st_intersects:          CrEOF\Spatial\ORM\Query\AST\Functions\MySql\STIntersects
+                        st_overlaps:            CrEOF\Spatial\ORM\Query\AST\Functions\MySql\STOverlaps
+                        st_touches:             CrEOF\Spatial\ORM\Query\AST\Functions\MySql\STTouches
+                        st_within:              CrEOF\Spatial\ORM\Query\AST\Functions\MySql\STWithin
                         touches:                CrEOF\Spatial\ORM\Query\AST\Functions\MySql\Touches
                         within:                 CrEOF\Spatial\ORM\Query\AST\Functions\MySql\Within
                         x:                      CrEOF\Spatial\ORM\Query\AST\Functions\MySql\X

--- a/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STBuffer.php
+++ b/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STBuffer.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright (C) 2013 luca capra
+ * Copyright (C) 2012 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,15 +27,14 @@ namespace CrEOF\Spatial\ORM\Query\AST\Functions\MySql;
 use CrEOF\Spatial\ORM\Query\AST\Functions\AbstractSpatialDQLFunction;
 
 /**
- * ST_Contains DQL function
+ * Description of STIntersects
  *
- * @author  luca capra <luca.capra@create-net.org>
- * @license http://dlambert.mit-license.org MIT
+ * @author Maximilian
  */
-class ST_Contains extends AbstractSpatialDQLFunction {
+class STBuffer extends AbstractSpatialDQLFunction {
 
     protected $platforms = array('mysql');
-    protected $functionName = 'ST_Contains';
+    protected $functionName = 'ST_Buffer';
     protected $minGeomExpr = 2;
     protected $maxGeomExpr = 2;
 

--- a/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STContains.php
+++ b/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STContains.php
@@ -27,15 +27,15 @@ namespace CrEOF\Spatial\ORM\Query\AST\Functions\MySql;
 use CrEOF\Spatial\ORM\Query\AST\Functions\AbstractSpatialDQLFunction;
 
 /**
- * ST_Overlaps DQL function
+ * STContains DQL function
  *
  * @author  luca capra <luca.capra@create-net.org>
- * @license http://mit-license.org MIT
+ * @license http://dlambert.mit-license.org MIT
  */
-class ST_Overlaps extends AbstractSpatialDQLFunction {
+class STContains extends AbstractSpatialDQLFunction {
 
     protected $platforms = array('mysql');
-    protected $functionName = 'ST_Overlaps';
+    protected $functionName = 'ST_Contains';
     protected $minGeomExpr = 2;
     protected $maxGeomExpr = 2;
 

--- a/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STCrosses.php
+++ b/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STCrosses.php
@@ -27,15 +27,15 @@ namespace CrEOF\Spatial\ORM\Query\AST\Functions\MySql;
 use CrEOF\Spatial\ORM\Query\AST\Functions\AbstractSpatialDQLFunction;
 
 /**
- * ST_Within DQL function
+ * STCrosses DQL function
  *
  * @author  luca capra <luca.capra@create-net.org>
  * @license http://dlambert.mit-license.org MIT
  */
-class ST_Within extends AbstractSpatialDQLFunction {
+class STCrosses extends AbstractSpatialDQLFunction {
 
     protected $platforms = array('mysql');
-    protected $functionName = 'ST_Within';
+    protected $functionName = 'ST_Crosses';
     protected $minGeomExpr = 2;
     protected $maxGeomExpr = 2;
 

--- a/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STDisjoint.php
+++ b/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STDisjoint.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright (C) 2012 Tom Vogt
+ * Copyright (C) 2013 luca capra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,15 +27,15 @@ namespace CrEOF\Spatial\ORM\Query\AST\Functions\MySql;
 use CrEOF\Spatial\ORM\Query\AST\Functions\AbstractSpatialDQLFunction;
 
 /**
- * ST_Touches DQL function
+ * STDisjoint DQL function
  *
- * @author  Tom Vogt <tom@lemuria.org>
- * @license http://mit-license.org MIT
+ * @author  luca capra <luca.capra@create-net.org>
+ * @license http://dlambert.mit-license.org MIT
  */
-class ST_Touches extends AbstractSpatialDQLFunction {
+class STDisjoint extends AbstractSpatialDQLFunction {
 
     protected $platforms = array('mysql');
-    protected $functionName = 'ST_Touches';
+    protected $functionName = 'ST_Disjoint';
     protected $minGeomExpr = 2;
     protected $maxGeomExpr = 2;
 

--- a/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STDistance.php
+++ b/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STDistance.php
@@ -27,12 +27,12 @@ namespace CrEOF\Spatial\ORM\Query\AST\Functions\MySql;
 use CrEOF\Spatial\ORM\Query\AST\Functions\AbstractSpatialDQLFunction;
 
 /**
- * ST_Distance DQL function
+ * STDistance DQL function
  *
  * @author  luca capra <luca.capra@create-net.org>
  * @license http://dlambert.mit-license.org MIT
  */
-class ST_Distance extends AbstractSpatialDQLFunction {
+class STDistance extends AbstractSpatialDQLFunction {
 
     protected $platforms = array('mysql');
     protected $functionName = 'ST_Distance';

--- a/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STEquals.php
+++ b/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STEquals.php
@@ -35,7 +35,7 @@ use CrEOF\Spatial\ORM\Query\AST\Functions\AbstractSpatialDQLFunction;
 class STEquals extends AbstractSpatialDQLFunction {
 
     protected $platforms = array('mysql');
-    protected $functionName = 'STEquals';
+    protected $functionName = 'ST_Equals';
     protected $minGeomExpr = 2;
     protected $maxGeomExpr = 2;
 

--- a/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STEquals.php
+++ b/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STEquals.php
@@ -27,15 +27,15 @@ namespace CrEOF\Spatial\ORM\Query\AST\Functions\MySql;
 use CrEOF\Spatial\ORM\Query\AST\Functions\AbstractSpatialDQLFunction;
 
 /**
- * ST_Crosses DQL function
+ * STEquals DQL function
  *
  * @author  luca capra <luca.capra@create-net.org>
  * @license http://dlambert.mit-license.org MIT
  */
-class ST_Crosses extends AbstractSpatialDQLFunction {
+class STEquals extends AbstractSpatialDQLFunction {
 
     protected $platforms = array('mysql');
-    protected $functionName = 'ST_Crosses';
+    protected $functionName = 'STEquals';
     protected $minGeomExpr = 2;
     protected $maxGeomExpr = 2;
 

--- a/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STIntersects.php
+++ b/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STIntersects.php
@@ -27,11 +27,11 @@ namespace CrEOF\Spatial\ORM\Query\AST\Functions\MySql;
 use CrEOF\Spatial\ORM\Query\AST\Functions\AbstractSpatialDQLFunction;
 
 /**
- * Description of ST_Intersects
+ * Description of STIntersects
  *
  * @author Maximilian
  */
-class ST_Intersects extends AbstractSpatialDQLFunction
+class STIntersects extends AbstractSpatialDQLFunction
 {
 	 protected $platforms = array('mysql');
 

--- a/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STOverlaps.php
+++ b/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STOverlaps.php
@@ -27,15 +27,15 @@ namespace CrEOF\Spatial\ORM\Query\AST\Functions\MySql;
 use CrEOF\Spatial\ORM\Query\AST\Functions\AbstractSpatialDQLFunction;
 
 /**
- * ST_Equals DQL function
+ * STOverlaps DQL function
  *
  * @author  luca capra <luca.capra@create-net.org>
- * @license http://dlambert.mit-license.org MIT
+ * @license http://mit-license.org MIT
  */
-class ST_Equals extends AbstractSpatialDQLFunction {
+class STOverlaps extends AbstractSpatialDQLFunction {
 
     protected $platforms = array('mysql');
-    protected $functionName = 'ST_Equals';
+    protected $functionName = 'ST_Overlaps';
     protected $minGeomExpr = 2;
     protected $maxGeomExpr = 2;
 

--- a/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STTouches.php
+++ b/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STTouches.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright (C) 2013 luca capra
+ * Copyright (C) 2012 Tom Vogt
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,15 +27,15 @@ namespace CrEOF\Spatial\ORM\Query\AST\Functions\MySql;
 use CrEOF\Spatial\ORM\Query\AST\Functions\AbstractSpatialDQLFunction;
 
 /**
- * ST_Disjoint DQL function
+ * STTouches DQL function
  *
- * @author  luca capra <luca.capra@create-net.org>
- * @license http://dlambert.mit-license.org MIT
+ * @author  Tom Vogt <tom@lemuria.org>
+ * @license http://mit-license.org MIT
  */
-class ST_Disjoint extends AbstractSpatialDQLFunction {
+class STTouches extends AbstractSpatialDQLFunction {
 
     protected $platforms = array('mysql');
-    protected $functionName = 'ST_Disjoint';
+    protected $functionName = 'ST_Touches';
     protected $minGeomExpr = 2;
     protected $maxGeomExpr = 2;
 

--- a/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STWithin.php
+++ b/lib/CrEOF/Spatial/ORM/Query/AST/Functions/MySql/STWithin.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright (C) 2012 Derek J. Lambert
+ * Copyright (C) 2013 luca capra
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -27,14 +27,15 @@ namespace CrEOF\Spatial\ORM\Query\AST\Functions\MySql;
 use CrEOF\Spatial\ORM\Query\AST\Functions\AbstractSpatialDQLFunction;
 
 /**
- * Description of ST_Intersects
+ * STWithin DQL function
  *
- * @author Maximilian
+ * @author  luca capra <luca.capra@create-net.org>
+ * @license http://dlambert.mit-license.org MIT
  */
-class ST_Buffer extends AbstractSpatialDQLFunction {
+class STWithin extends AbstractSpatialDQLFunction {
 
     protected $platforms = array('mysql');
-    protected $functionName = 'ST_Buffer';
+    protected $functionName = 'ST_Within';
     protected $minGeomExpr = 2;
     protected $maxGeomExpr = 2;
 


### PR DESCRIPTION
I've noticed that Doctrine doesn't pickup classes with the underscore eg ST_*
Refactored class names to ST* (Follow up of #11)

Best, Luca