### PR TITLE
Fix tests, bump doctrin/orm require, and add Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: php
+
+php:
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - hhvm
+
+env:
+  - DB=mysql
+  - DB=pgsql
+
+before_script:
+  - composer self-update
+  - composer install
+
+script:
+  - ./vendor/bin/phpunit -v -c tests/travis/travis.$DB.xml
+
+matrix:
+  exclude:
+    - php: hhvm
+      env: DB=pgsql  # driver for PostgreSQL currently unsupported by HHVM, requires 3rd party dependency
+
+sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Change log file to chronicle changes.
 - Stub TODO.md file.
 - CONTRIBUTING.md file with guidelines.
+- CrEOF\Spatial\Tests\OrmTest to removed dependency on doctrine/orm source for tests.
+- Travis-CI repo hook and configuration.
+
+### Changed
+- Minimum doctrine/orm version now 2.3.
+- All ORM tests now extend CrEOF\Spatial\Tests\OrmTest.
+- Specifying test platform through @group annotation has been deprecated. Tests now configure supported platforms in setUp().
+- Cleaned up existing test classes.
+- Replaced rhumsaa/array_column dev package dependency with ramsey/array_column. Prior has been abandoned and is no longer maintained.
+
+

--- a/composer.json
+++ b/composer.json
@@ -11,11 +11,9 @@
     ],
     "license": "MIT",
     "require": {
-        "doctrine/orm": ">=2.1"
+        "doctrine/orm": ">=2.3"
     },
     "require-dev": {
-        "doctrine/common": ">=2.1",
-        "doctrine/dbal": ">=2.1",
         "phpunit/phpunit": ">=4.8",
         "ramsey/array_column": "~1.1"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,6 @@
 
     <groups>
         <include>
-            <group>postgresql</group>        <!-- Tests specific to PostgreSQL -->
             <group>php</group>               <!-- Tests for PHP type objects -->
             <group>result_processing</group> <!-- Tests for lexer/parser/reader -->
             <group>geometry</group>          <!-- Tests for geometry types -->
@@ -20,9 +19,6 @@
             <group>geography</group>         <!-- Tests for geography types -->
             <group>srid</group>              <!-- Tests for SRID functionality -->
         </include>
-        <exclude>
-            <group>mysql</group>             <!-- Test specific to MySQL -->
-        </exclude>
     </groups>
 
     <php>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -32,13 +32,5 @@
         <var name="db_password" value="" />
         <var name="db_name" value="spatial_tests" />
         <var name="db_port" value="5432" />
-
-        <!-- Database for temporary connections (i.e. to drop/create the main database) -->
-        <var name="tmpdb_type" value="pdo_pgsql"/>
-        <var name="tmpdb_host" value="localhost"/>
-        <var name="tmpdb_username" value="postgres"/>
-        <var name="tmpdb_password" value=""/>
-        <var name="tmpdb_name" value="doctrine_tests_tmp"/>
-        <var name="tmpdb_port" value="5432"/>
     </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,6 +2,9 @@
 <phpunit backupGlobals="false"
          colors="true"
          bootstrap="./tests/CrEOF/Spatial/Tests/TestInit.php"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
         >
 
     <testsuites>

--- a/tests/CrEOF/Spatial/Tests/DBAL/Types/SchemaTest.php
+++ b/tests/CrEOF/Spatial/Tests/DBAL/Types/SchemaTest.php
@@ -45,6 +45,8 @@ class SchemaTest extends OrmTest
 
                 // Throws exception if mapping does not exist
                 $typeMapping = $this->getPlatform()->getDoctrineTypeMapping($fieldType);
+
+                $this->assertNotEmpty($typeMapping);
             }
         }
     }

--- a/tests/CrEOF/Spatial/Tests/Fixtures/GeographyEntity.php
+++ b/tests/CrEOF/Spatial/Tests/Fixtures/GeographyEntity.php
@@ -47,7 +47,7 @@ class GeographyEntity
     /**
      * @var GeographyInterface $geography
      *
-     * @Column(type="geography", nullable=true, options={"srid"="4326"})
+     * @Column(type="geography", nullable=true)
      */
     protected $geography;
 

--- a/tests/CrEOF/Spatial/Tests/Fixtures/GeometryEntity.php
+++ b/tests/CrEOF/Spatial/Tests/Fixtures/GeometryEntity.php
@@ -32,7 +32,7 @@ use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
  * @license http://dlambert.mit-license.org MIT
  *
  * @Entity
- * @Table(options={"engine"="MyISAM"})
+ * @Table()
  */
 class GeometryEntity
 {

--- a/tests/CrEOF/Spatial/Tests/Fixtures/LineStringEntity.php
+++ b/tests/CrEOF/Spatial/Tests/Fixtures/LineStringEntity.php
@@ -32,7 +32,7 @@ use CrEOF\Spatial\PHP\Types\Geometry\LineString;
  * @license http://dlambert.mit-license.org MIT
  *
  * @Entity
- * @Table(options={"engine"="MyISAM"})
+ * @Table()
  */
 class LineStringEntity
 {

--- a/tests/CrEOF/Spatial/Tests/Fixtures/NoHintGeometryEntity.php
+++ b/tests/CrEOF/Spatial/Tests/Fixtures/NoHintGeometryEntity.php
@@ -30,7 +30,7 @@ namespace CrEOF\Spatial\Tests\Fixtures;
  * @license http://dlambert.mit-license.org MIT
  *
  * @Entity
- * @Table(options={"engine"="MyISAM"})
+ * @Table()
  */
 class NoHintGeometryEntity
 {

--- a/tests/CrEOF/Spatial/Tests/Fixtures/PointEntity.php
+++ b/tests/CrEOF/Spatial/Tests/Fixtures/PointEntity.php
@@ -32,7 +32,7 @@ use CrEOF\Spatial\PHP\Types\Geometry\Point;
  * @license http://dlambert.mit-license.org MIT
  *
  * @Entity
- * @Table(options={"engine"="MyISAM"})
+ * @Table()
  */
 class PointEntity
 {

--- a/tests/CrEOF/Spatial/Tests/Fixtures/PolygonEntity.php
+++ b/tests/CrEOF/Spatial/Tests/Fixtures/PolygonEntity.php
@@ -32,7 +32,7 @@ use CrEOF\Spatial\PHP\Types\Geometry\Polygon;
  * @license http://dlambert.mit-license.org MIT
  *
  * @Entity
- * @Table(options={"engine"="MyISAM"})
+ * @Table()
  */
 class PolygonEntity
 {

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/AreaTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/AreaTest.php
@@ -36,7 +36,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group mysql
  * @group dql
  */
 class AreaTest extends OrmTest
@@ -44,6 +43,8 @@ class AreaTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('polygon');
+        $this->supportsPlatform('mysql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/AsBinaryTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/AsBinaryTest.php
@@ -35,7 +35,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group mysql
  * @group dql
  */
 class AsBinaryTest extends OrmTest
@@ -43,6 +42,8 @@ class AsBinaryTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('linestring');
+        $this->supportsPlatform('mysql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/AsTextTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/AsTextTest.php
@@ -35,7 +35,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group mysql
  * @group dql
  */
 class AsTextTest extends OrmTest
@@ -43,6 +42,8 @@ class AsTextTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('linestring');
+        $this->supportsPlatform('mysql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/ContainsTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/ContainsTest.php
@@ -36,7 +36,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group mysql
  * @group dql
  */
 class ContainsTest extends OrmTest
@@ -45,6 +44,8 @@ class ContainsTest extends OrmTest
     {
         $this->usesEntity('polygon');
         $this->usesType('point');
+        $this->supportsPlatform('mysql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/ContainsTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/ContainsTest.php
@@ -79,7 +79,7 @@ class ContainsTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p, Contains(p.polygon, GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, Contains(p.polygon, :p1) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
 
         $query->setParameter('p1', new Point(2, 2), 'point');
 
@@ -123,7 +123,7 @@ class ContainsTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Contains(p.polygon, GeomFromText(:p1)) = 1');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Contains(p.polygon, :p1) = 1');
 
         $query->setParameter('p1', new Point(6, 6), 'point');
 
@@ -134,7 +134,7 @@ class ContainsTest extends OrmTest
         $this->assertEquals($entity2, $result[1]);
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Contains(p.polygon, GeomFromText(:p1)) = 1');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Contains(p.polygon, :p1) = 1');
 
         $query->setParameter('p1', new Point(2, 2), 'point');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/DisjointTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/DisjointTest.php
@@ -92,7 +92,7 @@ class DisjointTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p, Disjoint(p.polygon, GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, Disjoint(p.polygon, :p1) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
 
         $query->setParameter('p1', new Polygon(array($lineString2)), 'polygon');
 
@@ -152,7 +152,7 @@ class DisjointTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Disjoint(p.polygon, GeomFromText(:p1)) = 1');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Disjoint(p.polygon, :p1) = 1');
 
         $query->setParameter('p1', new Polygon(array($lineString2)), 'polygon');
 
@@ -162,7 +162,7 @@ class DisjointTest extends OrmTest
         $this->assertEquals($entity3, $result[0]);
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Disjoint(p.polygon, GeomFromText(:p1)) = 1');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Disjoint(p.polygon, :p1) = 1');
 
         $query->setParameter('p1', new Polygon(array($lineString3)), 'polygon');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/DisjointTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/DisjointTest.php
@@ -36,7 +36,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group mysql
  * @group dql
  */
 class DisjointTest extends OrmTest
@@ -44,6 +43,8 @@ class DisjointTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('polygon');
+        $this->supportsPlatform('mysql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/EnvelopeTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/EnvelopeTest.php
@@ -36,7 +36,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group mysql
  * @group dql
  */
 class EnvelopeTest extends OrmTest
@@ -44,6 +43,8 @@ class EnvelopeTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('polygon');
+        $this->supportsPlatform('mysql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/EnvelopeTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/EnvelopeTest.php
@@ -138,7 +138,7 @@ class EnvelopeTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query        = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Envelope(p.polygon) = GeomFromText(:p1)');
+        $query        = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE Envelope(p.polygon) = :p1');
         $envelopeRing = new LineString(array(
                 new Point(0, 0),
                 new Point(10, 0),

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/GLengthTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/GLengthTest.php
@@ -35,7 +35,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group mysql
  * @group dql
  */
 class GLengthTest extends OrmTest
@@ -43,6 +42,8 @@ class GLengthTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('linestring');
+        $this->supportsPlatform('mysql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/GLengthTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/GLengthTest.php
@@ -101,7 +101,7 @@ class GLengthTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE GLength(GeomFromText(:p1)) > GLength(l.lineString)');
+        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE GLength(:p1) > GLength(l.lineString)');
 
         $query->setParameter('p1', $lineString, 'linestring');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/GeomFromTextTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/GeomFromTextTest.php
@@ -62,7 +62,7 @@ class GeomFromTextTest extends OrmTest
 
         $query = $this->getEntityManager()->createQuery('SELECT g FROM CrEOF\Spatial\Tests\Fixtures\GeometryEntity g WHERE g.geometry = GeomFromText(:geometry)');
 
-        $query->setParameter('geometry', new Point(5, 5), 'point');
+        $query->setParameter('geometry', 'POINT(5 5)', 'string');
 
         $result = $query->getResult();
 
@@ -90,7 +90,7 @@ class GeomFromTextTest extends OrmTest
 
         $query = $this->getEntityManager()->createQuery('SELECT g FROM CrEOF\Spatial\Tests\Fixtures\GeometryEntity g WHERE g.geometry = GeomFromText(:geometry)');
 
-        $query->setParameter('geometry', new LineString($value), 'linestring');
+        $query->setParameter('geometry', 'LINESTRING(0 0,5 5,10 10)', 'string');
 
         $result = $query->getResult();
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/GeomFromTextTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/GeomFromTextTest.php
@@ -35,7 +35,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group mysql
  * @group dql
  */
 class GeomFromTextTest extends OrmTest
@@ -44,6 +43,8 @@ class GeomFromTextTest extends OrmTest
     {
         $this->usesEntity('geometry');
         $this->usesType('point');
+        $this->supportsPlatform('mysql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/MBRContainsTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/MBRContainsTest.php
@@ -79,7 +79,7 @@ class MBRContainsTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p, MBRContains(p.polygon, GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, MBRContains(p.polygon, :p1) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
 
         $query->setParameter('p1', new Point(2, 2), 'point');
 
@@ -123,7 +123,7 @@ class MBRContainsTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE MBRContains(p.polygon, GeomFromText(:p1)) = 1');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE MBRContains(p.polygon, :p1) = 1');
 
         $query->setParameter('p1', new Point(6, 6), 'point');
 
@@ -134,7 +134,7 @@ class MBRContainsTest extends OrmTest
         $this->assertEquals($entity2, $result[1]);
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE MBRContains(p.polygon, GeomFromText(:p1)) = 1');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE MBRContains(p.polygon, :p1) = 1');
 
         $query->setParameter('p1', new Point(2, 2), 'point');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/MBRContainsTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/MBRContainsTest.php
@@ -36,7 +36,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group mysql
  * @group dql
  */
 class MBRContainsTest extends OrmTest
@@ -45,6 +44,8 @@ class MBRContainsTest extends OrmTest
     {
         $this->usesEntity('polygon');
         $this->usesType('point');
+        $this->supportsPlatform('mysql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/MBRDisjointTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/MBRDisjointTest.php
@@ -92,7 +92,7 @@ class MBRDisjointTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p, MBRDisjoint(p.polygon, GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, MBRDisjoint(p.polygon, :p1) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
 
         $query->setParameter('p1', new Polygon(array($lineString2)), 'polygon');
 
@@ -152,7 +152,7 @@ class MBRDisjointTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE MBRDisjoint(p.polygon, GeomFromText(:p1)) = 1');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE MBRDisjoint(p.polygon, :p1) = 1');
 
         $query->setParameter('p1', new Polygon(array($lineString2)), 'polygon');
 
@@ -162,7 +162,7 @@ class MBRDisjointTest extends OrmTest
         $this->assertEquals($entity3, $result[0]);
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE MBRDisjoint(p.polygon, GeomFromText(:p1)) = 1');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE MBRDisjoint(p.polygon, :p1) = 1');
 
         $query->setParameter('p1', new Polygon(array($lineString3)), 'polygon');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/MBRDisjointTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/MBRDisjointTest.php
@@ -36,7 +36,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group mysql
  * @group dql
  */
 class MBRDisjointTest extends OrmTest
@@ -44,6 +43,8 @@ class MBRDisjointTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('polygon');
+        $this->supportsPlatform('mysql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/StartPointTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/StartPointTest.php
@@ -35,7 +35,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group mysql
  * @group dql
  */
 class StartPointTest extends OrmTest
@@ -44,6 +43,8 @@ class StartPointTest extends OrmTest
     {
         $this->usesEntity('linestring');
         $this->usesType('point');
+        $this->supportsPlatform('mysql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/StartPointTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/MySql/StartPointTest.php
@@ -98,7 +98,7 @@ class StartPointTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE StartPoint(l.lineString) = GeomFromText(:p1)');
+        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE StartPoint(l.lineString) = :p1');
 
         $query->setParameter('p1', new Point(0, 0), 'point');
 
@@ -135,7 +135,7 @@ class StartPointTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE StartPoint(l.lineString) = StartPoint(GeomFromText(:p1))');
+        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE StartPoint(l.lineString) = StartPoint(:p1)');
 
         $query->setParameter('p1', $lineString2, 'linestring');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STAreaTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STAreaTest.php
@@ -36,7 +36,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group postgresql
  * @group dql
  */
 class STAreaTest extends OrmTest
@@ -44,6 +43,8 @@ class STAreaTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('polygon');
+        $this->supportsPlatform('postgresql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STAsBinaryTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STAsBinaryTest.php
@@ -36,7 +36,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group postgresql
  * @group dql
  */
 class STAsBinaryTest extends OrmTest
@@ -44,6 +43,8 @@ class STAsBinaryTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('linestring');
+        $this->supportsPlatform('postgresql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STAsTextTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STAsTextTest.php
@@ -35,7 +35,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group postgresql
  * @group dql
  */
 class STAsTextTest extends OrmTest
@@ -43,6 +42,8 @@ class STAsTextTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('linestring');
+        $this->supportsPlatform('postgresql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCentroidTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCentroidTest.php
@@ -36,7 +36,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group postgresql
  * @group dql
  */
 class STCentroidTest extends OrmTest
@@ -44,6 +43,8 @@ class STCentroidTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('polygon');
+        $this->supportsPlatform('postgresql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STClosestPointTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STClosestPointTest.php
@@ -36,7 +36,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group postgresql
  * @group dql
  */
 class STClosestPointTest extends OrmTest
@@ -45,6 +44,8 @@ class STClosestPointTest extends OrmTest
     {
         $this->usesEntity('polygon');
         $this->usesType('point');
+        $this->supportsPlatform('postgresql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STClosestPointTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STClosestPointTest.php
@@ -79,7 +79,7 @@ class STClosestPointTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p, ST_AsText(ST_ClosestPoint(p.polygon, ST_GeomFromText(:p1))) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, ST_AsText(ST_ClosestPoint(p.polygon, :p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
 
         $query->setParameter('p1', new Point(2, 2), 'point');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STContainsProperlyTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STContainsProperlyTest.php
@@ -36,7 +36,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group postgresql
  * @group dql
  */
 class STContainsProperlyTest extends OrmTest
@@ -44,6 +43,8 @@ class STContainsProperlyTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('polygon');
+        $this->supportsPlatform('postgresql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STContainsProperlyTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STContainsProperlyTest.php
@@ -78,7 +78,7 @@ class STContainsProperlyTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p, ST_ContainsProperly(p.polygon, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, ST_ContainsProperly(p.polygon, :p1) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
 
         $query->setParameter('p1', $lineString2, 'linestring');
 
@@ -122,7 +122,7 @@ class STContainsProperlyTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_ContainsProperly(p.polygon, ST_GeomFromText(:p1)) = true');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_ContainsProperly(p.polygon, :p1) = true');
 
         $query->setParameter('p1', $lineString2, 'linestring');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STContainsTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STContainsTest.php
@@ -79,7 +79,7 @@ class STContainsTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p, ST_Contains(p.polygon, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, ST_Contains(p.polygon, :p1) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
 
         $query->setParameter('p1', new Point(2, 2), 'point');
 
@@ -123,7 +123,7 @@ class STContainsTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Contains(p.polygon, ST_GeomFromText(:p1)) = true');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Contains(p.polygon, :p1) = true');
 
         $query->setParameter('p1', new Point(6, 6), 'point');
 
@@ -133,7 +133,7 @@ class STContainsTest extends OrmTest
         $this->assertEquals($entity1, $result[0]);
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Contains(p.polygon, ST_GeomFromText(:p1)) = true');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Contains(p.polygon, :p1) = true');
 
         $query->setParameter('p1', new Point(2, 2), 'point');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STContainsTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STContainsTest.php
@@ -36,7 +36,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group postgresql
  * @group dql
  */
 class STContainsTest extends OrmTest
@@ -45,6 +44,8 @@ class STContainsTest extends OrmTest
     {
         $this->usesEntity('polygon');
         $this->usesType('point');
+        $this->supportsPlatform('postgresql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCoveredByTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCoveredByTest.php
@@ -78,7 +78,7 @@ class STCoveredByTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p, ST_CoveredBy(p.polygon, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, ST_CoveredBy(p.polygon, :p1) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
 
         $query->setParameter('p1', new Polygon(array($lineString2)), 'polygon');
 
@@ -122,7 +122,7 @@ class STCoveredByTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_CoveredBy(p.polygon, ST_GeomFromText(:p1)) = true');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_CoveredBy(p.polygon, :p1) = true');
 
         $query->setParameter('p1', new Polygon(array($lineString2)), 'polygon');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCoveredByTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCoveredByTest.php
@@ -36,7 +36,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group postgresql
  * @group dql
  */
 class STCoveredByTest extends OrmTest
@@ -44,6 +43,8 @@ class STCoveredByTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('polygon');
+        $this->supportsPlatform('postgresql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCoversTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCoversTest.php
@@ -36,7 +36,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group postgresql
  * @group dql
  */
 class STCoversTest extends OrmTest
@@ -44,6 +43,8 @@ class STCoversTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('polygon');
+        $this->supportsPlatform('postgresql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCoversTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCoversTest.php
@@ -78,7 +78,7 @@ class STCoversTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p, ST_Covers(p.polygon, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, ST_Covers(p.polygon, :p1) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
 
         $query->setParameter('p1', new Polygon(array($lineString2)), 'polygon');
 
@@ -122,7 +122,7 @@ class STCoversTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Covers(p.polygon, ST_GeomFromText(:p1)) = true');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Covers(p.polygon, :p1) = true');
 
         $query->setParameter('p1', new Polygon(array($lineString2)), 'polygon');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCrossesTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCrossesTest.php
@@ -35,7 +35,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group postgresql
  * @group dql
  */
 class STCrossesTest extends OrmTest
@@ -43,6 +42,8 @@ class STCrossesTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('linestring');
+        $this->supportsPlatform('postgresql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCrossesTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STCrossesTest.php
@@ -81,7 +81,7 @@ class STCrossesTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT l, ST_Crosses(l.lineString, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $query = $this->getEntityManager()->createQuery('SELECT l, ST_Crosses(l.lineString, :p1) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
 
         $query->setParameter('p1', $lineString1, 'linestring');
 
@@ -131,7 +131,7 @@ class STCrossesTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_Crosses(l.lineString, ST_GeomFromText(:p1)) = true');
+        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_Crosses(l.lineString, :p1) = true');
 
         $query->setParameter('p1', $lineString1, 'linestring');
 
@@ -141,7 +141,7 @@ class STCrossesTest extends OrmTest
         $this->assertEquals($entity2, $result[0]);
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_Crosses(l.lineString, ST_GeomFromText(:p1)) = true');
+        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_Crosses(l.lineString, :p1) = true');
 
         $query->setParameter('p1', $lineString3, 'linestring');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STDisjointTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STDisjointTest.php
@@ -92,7 +92,7 @@ class STDisjointTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p, ST_Disjoint(p.polygon, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, ST_Disjoint(p.polygon, :p1) FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p');
 
         $query->setParameter('p1', new Polygon(array($lineString2)), 'polygon');
 
@@ -152,7 +152,7 @@ class STDisjointTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Disjoint(p.polygon, ST_GeomFromText(:p1)) = true');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Disjoint(p.polygon, :p1) = true');
 
         $query->setParameter('p1', new Polygon(array($lineString2)), 'polygon');
 
@@ -162,7 +162,7 @@ class STDisjointTest extends OrmTest
         $this->assertEquals($entity3, $result[0]);
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Disjoint(p.polygon, ST_GeomFromText(:p1)) = true');
+        $query = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Disjoint(p.polygon, :p1) = true');
 
         $query->setParameter('p1', new Polygon(array($lineString3)), 'polygon');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STDisjointTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STDisjointTest.php
@@ -36,7 +36,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group postgresql
  * @group dql
  */
 class STDisjointTest extends OrmTest
@@ -44,6 +43,8 @@ class STDisjointTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('polygon');
+        $this->supportsPlatform('postgresql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STDistanceSphereTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STDistanceSphereTest.php
@@ -74,7 +74,7 @@ class STDistanceSphereTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p, ST_Distance_Sphere(p.point, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PointEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, ST_Distance_Sphere(p.point, :p1) FROM CrEOF\Spatial\Tests\Fixtures\PointEntity p');
 
         $query->setParameter('p1', $madison, 'point');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STDistanceSphereTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STDistanceSphereTest.php
@@ -36,7 +36,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group postgresql
  * @group dql
  */
 class STDistanceSphereTest extends OrmTest
@@ -44,6 +43,8 @@ class STDistanceSphereTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('point');
+        $this->supportsPlatform('postgresql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STDistanceTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STDistanceTest.php
@@ -36,7 +36,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group postgresql
  * @group dql
  */
 class STDistanceTest extends OrmTest
@@ -46,6 +45,8 @@ class STDistanceTest extends OrmTest
         $this->usesEntity('point');
         $this->usesEntity('geography');
         $this->usesType('geopoint');
+        $this->supportsPlatform('postgresql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STDistanceTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STDistanceTest.php
@@ -76,7 +76,7 @@ class STDistanceTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT p, ST_Distance(p.point, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\PointEntity p');
+        $query = $this->getEntityManager()->createQuery('SELECT p, ST_Distance(p.point, :p1) FROM CrEOF\Spatial\Tests\Fixtures\PointEntity p');
 
         $query->setParameter('p1', $madison, 'point');
 
@@ -118,7 +118,7 @@ class STDistanceTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT g, ST_Distance(g.geography, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\GeographyEntity g');
+        $query = $this->getEntityManager()->createQuery('SELECT g, ST_Distance(g.geography, :p1) FROM CrEOF\Spatial\Tests\Fixtures\GeographyEntity g');
 
         $query->setParameter('p1', $madison, 'geopoint');
 
@@ -160,7 +160,7 @@ class STDistanceTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT g, ST_Distance(g.geography, ST_GeomFromText(:p1), false) FROM CrEOF\Spatial\Tests\Fixtures\GeographyEntity g');
+        $query = $this->getEntityManager()->createQuery('SELECT g, ST_Distance(g.geography, :p1, false) FROM CrEOF\Spatial\Tests\Fixtures\GeographyEntity g');
 
         $query->setParameter('p1', $madison, 'geopoint');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STEnvelopeTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STEnvelopeTest.php
@@ -138,7 +138,7 @@ class STEnvelopeTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query        = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Envelope(p.polygon) = ST_GeomFromText(:p1)');
+        $query        = $this->getEntityManager()->createQuery('SELECT p FROM CrEOF\Spatial\Tests\Fixtures\PolygonEntity p WHERE ST_Envelope(p.polygon) = :p1');
         $envelopeRing = new LineString(array(
                 new Point(0, 0),
                 new Point(10, 0),

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STEnvelopeTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STEnvelopeTest.php
@@ -36,7 +36,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group postgresql
  * @group dql
  */
 class STEnvelopeTest extends OrmTest
@@ -44,6 +43,8 @@ class STEnvelopeTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('polygon');
+        $this->supportsPlatform('postgresql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STGeomFromTextTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STGeomFromTextTest.php
@@ -35,7 +35,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group postgresql
  * @group dql
  */
 class STGeomFromTextTest extends OrmTest
@@ -43,6 +42,8 @@ class STGeomFromTextTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('geometry');
+        $this->supportsPlatform('postgresql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STGeomFromTextTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STGeomFromTextTest.php
@@ -60,7 +60,7 @@ class STGeomFromTextTest extends OrmTest
 
         $query = $this->getEntityManager()->createQuery('SELECT g FROM CrEOF\Spatial\Tests\Fixtures\GeometryEntity g WHERE g.geometry = ST_GeomFromText(:geometry)');
 
-        $query->setParameter('geometry', new Point(5, 5), 'point');
+        $query->setParameter('geometry', 'POINT(5 5)', 'string');
 
         $result = $query->getResult();
 
@@ -88,7 +88,7 @@ class STGeomFromTextTest extends OrmTest
 
         $query = $this->getEntityManager()->createQuery('SELECT g FROM CrEOF\Spatial\Tests\Fixtures\GeometryEntity g WHERE g.geometry = ST_GeomFromText(:geometry)');
 
-        $query->setParameter('geometry', new LineString($value), 'linestring');
+        $query->setParameter('geometry', 'LINESTRING(0 0,5 5,10 10)', 'string');
 
         $result = $query->getResult();
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STLengthTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STLengthTest.php
@@ -99,7 +99,7 @@ class STLengthTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_Length(ST_GeomFromText(:p1)) > ST_Length(l.lineString)');
+        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_Length(:p1) > ST_Length(l.lineString)');
 
         $query->setParameter('p1', $lineString, 'linestring');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STLengthTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STLengthTest.php
@@ -35,7 +35,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group postgresql
  * @group dql
  */
 class STLengthTest extends OrmTest
@@ -43,6 +42,8 @@ class STLengthTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('linestring');
+        $this->supportsPlatform('postgresql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STLineCrossingDirectionTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STLineCrossingDirectionTest.php
@@ -35,7 +35,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group postgresql
  * @group dql
  */
 class STLineCrossingDirectionTest extends OrmTest
@@ -43,6 +42,8 @@ class STLineCrossingDirectionTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('linestring');
+        $this->supportsPlatform('postgresql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STLineCrossingDirectionTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STLineCrossingDirectionTest.php
@@ -90,7 +90,7 @@ class STLineCrossingDirectionTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT l, ST_LineCrossingDirection(l.lineString, ST_GeomFromText(:p1)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $query = $this->getEntityManager()->createQuery('SELECT l, ST_LineCrossingDirection(l.lineString, :p1) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
 
         $query->setParameter('p1', $lineString4, 'linestring');
 
@@ -149,7 +149,7 @@ class STLineCrossingDirectionTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_LineCrossingDirection(l.lineString, ST_GeomFromText(:p1)) = 1');
+        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_LineCrossingDirection(l.lineString, :p1) = 1');
 
         $query->setParameter('p1', $lineString4, 'linestring');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STStartPointTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STStartPointTest.php
@@ -35,7 +35,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group postgresql
  * @group dql
  */
 class STStartPointTest extends OrmTest
@@ -43,6 +42,8 @@ class STStartPointTest extends OrmTest
     protected function setUp()
     {
         $this->usesEntity('linestring');
+        $this->supportsPlatform('postgresql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STStartPointTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STStartPointTest.php
@@ -97,7 +97,7 @@ class STStartPointTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_StartPoint(l.lineString) = ST_GeomFromText(:p1)');
+        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_StartPoint(l.lineString) = :p1');
 
         $query->setParameter('p1', new Point(0, 0), 'point');
 
@@ -134,7 +134,7 @@ class STStartPointTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_StartPoint(l.lineString) = ST_StartPoint(ST_GeomFromText(:p1))');
+        $query = $this->getEntityManager()->createQuery('SELECT l FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l WHERE ST_StartPoint(l.lineString) = ST_StartPoint(:p1)');
 
         $query->setParameter('p1', $lineString2, 'linestring');
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STSummarayTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/AST/Functions/PostgreSql/STSummarayTest.php
@@ -40,7 +40,6 @@ use Doctrine\ORM\Query;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  *
- * @group postgresql
  * @group dql
  */
 class STSummaryTest extends OrmTest
@@ -49,6 +48,8 @@ class STSummaryTest extends OrmTest
     {
         $this->usesEntity('geometry');
         $this->usesEntity('geography');
+        $this->supportsPlatform('postgresql');
+
         parent::setUp();
     }
 

--- a/tests/CrEOF/Spatial/Tests/ORM/Query/GeometryWalkerTest.php
+++ b/tests/CrEOF/Spatial/Tests/ORM/Query/GeometryWalkerTest.php
@@ -46,10 +46,9 @@ class GeometryWalkerTest extends OrmTest
     }
 
     /**
-     * @group mysql
      * @group geometry
      */
-    public function testGeometryWalkerBinaryMySql()
+    public function testGeometryWalkerBinary()
     {
         $lineString1 = new LineString(array(
             new Point(0, 0),
@@ -73,14 +72,29 @@ class GeometryWalkerTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT AsBinary(StartPoint(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        switch ($this->getPlatform()->getName()) {
+            case 'mysql':
+                $asBinary   = 'AsBinary';
+                $startPoint = 'StartPoint';
+                $envelope   = 'Envelope';
+                break;
+            default:
+                $asBinary   = 'ST_AsBinary';
+                $startPoint = 'ST_StartPoint';
+                $envelope   = 'ST_Envelope';
+                break;
+        }
+
+        $queryString = sprintf('SELECT %s(%s(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l', $asBinary, $startPoint);
+        $query = $this->getEntityManager()->createQuery($queryString);
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'CrEOF\Spatial\ORM\Query\GeometryWalker');
 
         $result = $query->getResult();
         $this->assertEquals(new Point(0, 0), $result[0][1]);
         $this->assertEquals(new Point(3, 3), $result[1][1]);
 
-        $query = $this->getEntityManager()->createQuery('SELECT AsBinary(Envelope(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $queryString = sprintf('SELECT %s(%s(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l', $asBinary, $envelope);
+        $query = $this->getEntityManager()->createQuery($queryString);
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'CrEOF\Spatial\ORM\Query\GeometryWalker');
 
         $result = $query->getResult();
@@ -89,10 +103,9 @@ class GeometryWalkerTest extends OrmTest
     }
 
     /**
-     * @group postgresql
      * @group geometry
      */
-    public function testGeometryWalkerBinaryPostgreSql()
+    public function testGeometryWalkerText()
     {
         $lineString1 = new LineString(array(
             new Point(0, 0),
@@ -116,100 +129,29 @@ class GeometryWalkerTest extends OrmTest
         $this->getEntityManager()->flush();
         $this->getEntityManager()->clear();
 
-        $query = $this->getEntityManager()->createQuery('SELECT ST_AsBinary(ST_StartPoint(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        switch ($this->getPlatform()->getName()) {
+            case 'mysql':
+                $asText   = 'AsText';
+                $startPoint = 'StartPoint';
+                $envelope   = 'Envelope';
+                break;
+            default:
+                $asText   = 'ST_AsText';
+                $startPoint = 'ST_StartPoint';
+                $envelope   = 'ST_Envelope';
+                break;
+        }
+
+        $queryString = sprintf('SELECT %s(%s(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l', $asText, $startPoint);
+        $query = $this->getEntityManager()->createQuery($queryString);
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'CrEOF\Spatial\ORM\Query\GeometryWalker');
 
         $result = $query->getResult();
         $this->assertEquals(new Point(0, 0), $result[0][1]);
         $this->assertEquals(new Point(3, 3), $result[1][1]);
 
-        $query = $this->getEntityManager()->createQuery('SELECT ST_AsBinary(ST_Envelope(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
-        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'CrEOF\Spatial\ORM\Query\GeometryWalker');
-
-        $result = $query->getResult();
-        $this->assertInstanceOf('CrEOF\Spatial\PHP\Types\Geometry\Polygon', $result[0][1]);
-        $this->assertInstanceOf('CrEOF\Spatial\PHP\Types\Geometry\Polygon', $result[1][1]);
-    }
-
-    /**
-     * @group mysql
-     * @group geometry
-     */
-    public function testGeometryWalkerTextMySql()
-    {
-        $lineString1 = new LineString(array(
-            new Point(0, 0),
-            new Point(2, 2),
-            new Point(5, 5)
-        ));
-        $lineString2 = new LineString(array(
-            new Point(3, 3),
-            new Point(4, 15),
-            new Point(5, 22)
-        ));
-        $entity1 = new LineStringEntity();
-
-        $entity1->setLineString($lineString1);
-        $this->getEntityManager()->persist($entity1);
-
-        $entity2 = new LineStringEntity();
-
-        $entity2->setLineString($lineString2);
-        $this->getEntityManager()->persist($entity2);
-        $this->getEntityManager()->flush();
-        $this->getEntityManager()->clear();
-
-        $query = $this->getEntityManager()->createQuery('SELECT AsText(StartPoint(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
-        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'CrEOF\Spatial\ORM\Query\GeometryWalker');
-
-        $result = $query->getResult();
-        $this->assertEquals(new Point(0, 0), $result[0][1]);
-        $this->assertEquals(new Point(3, 3), $result[1][1]);
-
-        $query = $this->getEntityManager()->createQuery('SELECT AsText(Envelope(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
-        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'CrEOF\Spatial\ORM\Query\GeometryWalker');
-
-        $result = $query->getResult();
-        $this->assertInstanceOf('CrEOF\Spatial\PHP\Types\Geometry\Polygon', $result[0][1]);
-        $this->assertInstanceOf('CrEOF\Spatial\PHP\Types\Geometry\Polygon', $result[1][1]);
-    }
-
-    /**
-     * @group postgresql
-     * @group geometry
-     */
-    public function testGeometryWalkerTextPostgreSql()
-    {
-        $lineString1 = new LineString(array(
-            new Point(0, 0),
-            new Point(2, 2),
-            new Point(5, 5)
-        ));
-        $lineString2 = new LineString(array(
-            new Point(3, 3),
-            new Point(4, 15),
-            new Point(5, 22)
-        ));
-        $entity1 = new LineStringEntity();
-
-        $entity1->setLineString($lineString1);
-        $this->getEntityManager()->persist($entity1);
-
-        $entity2 = new LineStringEntity();
-
-        $entity2->setLineString($lineString2);
-        $this->getEntityManager()->persist($entity2);
-        $this->getEntityManager()->flush();
-        $this->getEntityManager()->clear();
-
-        $query = $this->getEntityManager()->createQuery('SELECT ST_AsText(ST_StartPoint(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
-        $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'CrEOF\Spatial\ORM\Query\GeometryWalker');
-
-        $result = $query->getResult();
-        $this->assertEquals(new Point(0, 0), $result[0][1]);
-        $this->assertEquals(new Point(3, 3), $result[1][1]);
-
-        $query = $this->getEntityManager()->createQuery('SELECT ST_AsText(ST_Envelope(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l');
+        $queryString = sprintf('SELECT %s(%s(l.lineString)) FROM CrEOF\Spatial\Tests\Fixtures\LineStringEntity l', $asText, $envelope);
+        $query = $this->getEntityManager()->createQuery($queryString);
         $query->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'CrEOF\Spatial\ORM\Query\GeometryWalker');
 
         $result = $query->getResult();

--- a/tests/CrEOF/Spatial/Tests/OrmTest.php
+++ b/tests/CrEOF/Spatial/Tests/OrmTest.php
@@ -244,7 +244,7 @@ abstract class OrmTest extends \PHPUnit_Framework_TestCase
 
                 // Since doctrineTypeComments may already be initialized check if added type requires comment
                 if (Type::getType($typeName)->requiresSQLCommentHint($this->getPlatform())) {
-                    $this->getPlatform()->markDoctrineTypeCommented($typeName);
+                    $this->getPlatform()->markDoctrineTypeCommented(Type::getType($typeName));
                 }
 
                 static::$addedTypes[$typeName] = true;

--- a/tests/CrEOF/Spatial/Tests/OrmTest.php
+++ b/tests/CrEOF/Spatial/Tests/OrmTest.php
@@ -68,6 +68,11 @@ abstract class OrmTest extends \PHPUnit_Framework_TestCase
     /**
      * @var bool[]
      */
+    protected $supportedPlatforms = array();
+
+    /**
+     * @var bool[]
+     */
     protected static $createdEntities = array();
 
     /**
@@ -155,6 +160,10 @@ abstract class OrmTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
+        if (count($this->supportedPlatforms) && ! in_array($this->getPlatform()->getName(), $this->supportedPlatforms, true)) {
+            $this->markTestSkipped();
+        }
+
         $this->entityManager = $this->getEntityManager();
         $this->schemaTool    = $this->getSchemaTool();
 
@@ -211,6 +220,14 @@ abstract class OrmTest extends \PHPUnit_Framework_TestCase
     protected function usesType($typeName)
     {
         $this->usedTypes[$typeName] = true;
+    }
+
+    /**
+     * @param string $platform
+     */
+    protected function supportsPlatform($platform)
+    {
+        $this->supportedPlatforms[$platform] = true;
     }
 
     /**

--- a/tests/CrEOF/Spatial/Tests/OrmTest.php
+++ b/tests/CrEOF/Spatial/Tests/OrmTest.php
@@ -159,7 +159,7 @@ abstract class OrmTest extends \PHPUnit_Framework_TestCase
         $this->schemaTool    = $this->getSchemaTool();
 
         if (true) {
-            static::getConnection()->executeQuery('SELECT 1 /*' . get_class($this) . '*/');
+            static::getConnection()->executeQuery(sprintf('SELECT 1 /*%s*//*%s*/', get_class($this), $this->getName()));
         }
 
         $this->sqlLoggerStack->enabled = true;
@@ -261,6 +261,7 @@ abstract class OrmTest extends \PHPUnit_Framework_TestCase
 
         foreach (array_keys($this->usedEntities) as $entityName) {
             if (! isset(static::$createdEntities[$entityName])) {
+                //TODO: getClassMetadata marked internal in 2.5
                 $classes[] = $this->getEntityManager()->getClassMetadata(static::$entities[$entityName]['class']);
 
                 static::$createdEntities[$entityName] = true;

--- a/tests/CrEOF/Spatial/Tests/OrmTest.php
+++ b/tests/CrEOF/Spatial/Tests/OrmTest.php
@@ -161,7 +161,7 @@ abstract class OrmTest extends \PHPUnit_Framework_TestCase
     protected function setUp()
     {
         if (count($this->supportedPlatforms) && ! in_array($this->getPlatform()->getName(), $this->supportedPlatforms, true)) {
-            $this->markTestSkipped();
+            $this->markTestSkipped(sprintf('No support for platform %s in test class %s.', $this->getPlatform()->getName(), get_class($this)));
         }
 
         $this->entityManager = $this->getEntityManager();

--- a/tests/travis/travis.mysql.xml
+++ b/tests/travis/travis.mysql.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit backupGlobals="false"
+         colors="true"
+         bootstrap="../CrEOF/Spatial/Tests/TestInit.php"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
+        >
+
+    <testsuites>
+        <testsuite>
+            <directory>./tests/CrEOF/Spatial/Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <groups>
+        <include>
+            <group>php</group>               <!-- Tests for PHP type objects -->
+            <group>result_processing</group> <!-- Tests for lexer/parser/reader -->
+            <group>geometry</group>          <!-- Tests for geometry types -->
+            <group>dql</group>               <!-- Tests for DQL functions -->
+            <group>geography</group>         <!-- Tests for geography types -->
+        </include>
+        <exclude>
+            <group>srid</group>              <!-- Tests for SRID functionality -->
+        </exclude>
+    </groups>
+
+    <php>
+        <var name="db_type" value="pdo_mysql"/>
+        <var name="db_host" value="127.0.0.1" />
+        <var name="db_username" value="root" />
+        <var name="db_password" value="" />
+        <var name="db_name" value="spatial_tests" />
+        <var name="db_port" value="3306" />
+    </php>
+</phpunit>

--- a/tests/travis/travis.pgsql.xml
+++ b/tests/travis/travis.pgsql.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<phpunit backupGlobals="false"
+         colors="true"
+         bootstrap="../CrEOF/Spatial/Tests/TestInit.php"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
+        >
+
+    <testsuites>
+        <testsuite>
+            <directory>./tests/CrEOF/Spatial/Tests</directory>
+        </testsuite>
+    </testsuites>
+
+    <groups>
+        <include>
+            <group>php</group>               <!-- Tests for PHP type objects -->
+            <group>result_processing</group> <!-- Tests for lexer/parser/reader -->
+            <group>geometry</group>          <!-- Tests for geometry types -->
+            <group>dql</group>               <!-- Tests for DQL functions -->
+            <group>geography</group>         <!-- Tests for geography types -->
+            <group>srid</group>              <!-- Tests for SRID functionality -->
+        </include>
+    </groups>
+
+    <php>
+        <var name="db_type" value="pdo_pgsql"/>
+        <var name="db_host" value="localhost" />
+        <var name="db_username" value="postgres" />
+        <var name="db_password" value="" />
+        <var name="db_name" value="spatial_tests" />
+        <var name="db_port" value="5432" />
+    </php>
+</phpunit>


### PR DESCRIPTION
Updated doctrine require to version 2.3. All tests now passing on PostgreSQL and MySQL for doctrine 2.3 thru 2.5. Added Travis-CI config to test all supported versions of PHP.