### PR TITLE
Replace CodeClimate coverage with Coveralls

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,8 +1,9 @@
----
 engines:
   phpcodesniffer:
     enabled: true
   phpmd:
+    enabled: true
+  codeclimate-fixme
     enabled: true
 ratings:
   paths:

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+coverage_clover: ./build/logs/clover-*.xml
+service_name: travis-ci

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,3 +1,2 @@
 coverage_clover: ./build/logs/clover-*.xml
-service_name: travis-ci
 src_dir: lib

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,3 @@
 coverage_clover: ./build/logs/clover-*.xml
 service_name: travis-ci
+src_dir: lib

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,12 @@ php:
   - hhvm
 
 env:
-  - ORM=2.3
-  - ORM=2.4
-  - ORM=2.5
+  - DB=mysql ORM=2.3
+  - DB=mysql ORM=2.4
+  - DB=mysql ORM=2.5
+  - DB=pgsql ORM=2.3
+  - DB=pgsql ORM=2.4
+  - DB=pgsql ORM=2.5
 
 before_script:
   - composer self-update
@@ -20,17 +23,21 @@ before_script:
   - composer install --prefer-source
 
 script:
-  - DB=mysql ./vendor/bin/phpunit -v -c ./tests/travis/travis.mysql.xml --coverage-clover ./build/logs/clover-mysql.xml
-  - DB=pgsql ./vendor/bin/phpunit -v -c ./tests/travis/travis.pgsql.xml --coverage-clover ./build/logs/clover-pgsql.xml
+  - ./vendor/bin/phpunit -v -c ./tests/travis/travis.$DB.xml --coverage-clover ./build/logs/clover-$TRAVIS_PHP_VERSION-$ORM-$DB.xml
 
 after_script:
-  - ./vendor/bin/test-reporter --coverage-report ./build/logs/clover-mysql.xml --coverage-report ./build/logs/clover-pgsql.xml
+  - ./vendor/bin/coveralls -v
 
 matrix:
-  allow_failures:
-    - php: hhvm   # driver for PostgreSQL currently unsupported by HHVM, requires 3rd party dependency
-    - php: 7.0    # PHP 7 requires PHPUnit 5, work needed to support the later
-
   exclude:
+    - php: 7.0               # PHP 7 requires PHPUnit 5, work needed to support the later
+    - php: hhvm
+      env: DB=pgsql ORM=2.3  # driver for PostgreSQL currently unsupported by HHVM, requires 3rd party dependency
+    - php: hhvm
+      env: DB=pgsql ORM=2.4  # driver for PostgreSQL currently unsupported by HHVM, requires 3rd party dependency
+    - php: hhvm
+      env: DB=pgsql ORM=2.5  # driver for PostgreSQL currently unsupported by HHVM, requires 3rd party dependency
     - php: 5.3
-      env: ORM=2.5  # ORM >=2.5 requires PHP >=5.4
+      env: DB=mysql ORM=2.5  # ORM >=2.5 requires PHP >=5.4
+    - php: 5.3
+      env: DB=pgsql ORM=2.5  # ORM >=2.5 requires PHP >=5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,9 @@ script:
 after_script:
   - ./vendor/bin/coveralls -v
 
+notifications:
+  webhooks: https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN
+
 matrix:
   exclude:
     - php: 7.0               # PHP 7 requires PHPUnit 5, work needed to support the later

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ after_script:
   - ./vendor/bin/coveralls -v
 
 notifications:
-  webhooks: https://coveralls.io/webhook?repo_token=$COVERALLS_REPO_TOKEN
+  webhooks: https://coveralls.io/webhook?repo_token=$COVERALLS_WEBHOOK
 
 matrix:
   exclude:

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "phpunit/phpunit": ">=4.8",
         "ramsey/array_column": "~1.1",
-        "codeclimate/php-test-reporter": "dev-master"
+        "satooshi/php-coveralls": "dev-master"
     },
     "autoload": {
         "psr-0": {

--- a/tests/travis/composer.orm2.3.json
+++ b/tests/travis/composer.orm2.3.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "phpunit/phpunit": ">=4.8",
         "ramsey/array_column": "~1.1",
-		"codeclimate/php-test-reporter": "@dev"
+        "satooshi/php-coveralls": "dev-master"
     },
     "autoload": {
         "psr-0": {

--- a/tests/travis/composer.orm2.4.json
+++ b/tests/travis/composer.orm2.4.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "phpunit/phpunit": ">=4.8",
         "ramsey/array_column": "~1.1",
-		"codeclimate/php-test-reporter": "@dev"
+        "satooshi/php-coveralls": "dev-master"
     },
     "autoload": {
         "psr-0": {

--- a/tests/travis/composer.orm2.5.json
+++ b/tests/travis/composer.orm2.5.json
@@ -16,7 +16,7 @@
     "require-dev": {
         "phpunit/phpunit": ">=4.8",
         "ramsey/array_column": "~1.1",
-        "codeclimate/php-test-reporter": "@dev"
+        "satooshi/php-coveralls": "dev-master"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Coveralls will test multiple builds. CodeClimate will continue to be used for codesniff and mess detection.