### PR TITLE
Adding scientific notation fix with tests

### DIFF
--- a/lib/CrEOF/Spatial/DBAL/Types/StringLexer.php
+++ b/lib/CrEOF/Spatial/DBAL/Types/StringLexer.php
@@ -34,6 +34,7 @@ class StringLexer extends \Doctrine\Common\Lexer
     const T_NONE               = 1;
     const T_INTEGER            = 2;
     const T_STRING             = 3;
+    const T_E                  = 4;
     const T_FLOAT              = 5;
     const T_CLOSE_PARENTHESIS  = 6;
     const T_OPEN_PARENTHESIS   = 7;
@@ -77,6 +78,8 @@ class StringLexer extends \Doctrine\Common\Lexer
                 $value = (int) $value;
 
                 return self::T_INTEGER;
+            case ($value === 'e'):
+                return self::T_E;
             case (ctype_alpha($value)):
                 $name = __CLASS__ . '::T_' . strtoupper($value);
 

--- a/lib/CrEOF/Spatial/DBAL/Types/StringParser.php
+++ b/lib/CrEOF/Spatial/DBAL/Types/StringParser.php
@@ -122,6 +122,16 @@ class StringParser
     protected function coordinate()
     {
         $this->match(($this->lexer->isNextToken(StringLexer::T_FLOAT) ? StringLexer::T_FLOAT : StringLexer::T_INTEGER));
+		
+		if($this->lexer->isNextToken(StringLexer::T_STRING)){
+            $number = $this->lexer->token['value'];
+            $this->match(StringLexer::T_STRING);
+			if($this->lexer->token['value']!='e'){
+                $this->syntaxError('e',$this->lexer->token['value']);
+            }
+            $this->match(StringLexer::T_INTEGER);
+            return $number*pow(10,$this->lexer->token['value']);
+        }
 
         return $this->lexer->token['value'];
     }

--- a/lib/CrEOF/Spatial/DBAL/Types/StringParser.php
+++ b/lib/CrEOF/Spatial/DBAL/Types/StringParser.php
@@ -123,12 +123,9 @@ class StringParser
     {
         $this->match(($this->lexer->isNextToken(StringLexer::T_FLOAT) ? StringLexer::T_FLOAT : StringLexer::T_INTEGER));
 		
-		if($this->lexer->isNextToken(StringLexer::T_STRING)){
+		if($this->lexer->isNextToken(StringLexer::T_E)){
             $number = $this->lexer->token['value'];
-            $this->match(StringLexer::T_STRING);
-			if($this->lexer->token['value']!='e'){
-                $this->syntaxError('e',$this->lexer->token['value']);
-            }
+            $this->match(StringLexer::T_E);
             $this->match(StringLexer::T_INTEGER);
             return $number*pow(10,$this->lexer->token['value']);
         }

--- a/tests/CrEOF/Spatial/Tests/DBAL/Types/StringParserTest.php
+++ b/tests/CrEOF/Spatial/Tests/DBAL/Types/StringParserTest.php
@@ -118,7 +118,7 @@ class StringParserTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException        \CrEOF\Spatial\Exception\InvalidValueException
-     * @expectedExceptionMessage [Syntax Error] line 0, col 5: Error: Expected 'e', got "test" in value "SRID=4326;POINT(4.23test-005 -8e-003)"
+     * @expectedExceptionMessage [Syntax Error] line 0, col 20: Error: Expected CrEOF\Spatial\DBAL\Types\StringLexer::T_INTEGER, got "test" in value "SRID=4326;POINT(4.23test-005 -8e-003)"
      */
     public function testParsingWrongPointScientificValueWithSrid()
     {

--- a/tests/CrEOF/Spatial/Tests/DBAL/Types/StringParserTest.php
+++ b/tests/CrEOF/Spatial/Tests/DBAL/Types/StringParserTest.php
@@ -100,6 +100,33 @@ class StringParserTest extends \PHPUnit_Framework_TestCase
 
         $parser->parse();
     }
+	
+	 public function testParsingPointScientificValueWithSrid()
+    {
+        $value    = 'SRID=4326;POINT(4.23e-005 -8e-003)';
+        $parser   = new StringParser($value);
+        $expected = array(
+            'srid'  => 4326,
+            'type'  => 'POINT',
+            'value' => array(0.0000423, -0.008)
+        );
+
+        $actual = $parser->parse();
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /**
+     * @expectedException        \CrEOF\Spatial\Exception\InvalidValueException
+     * @expectedExceptionMessage [Syntax Error] line 0, col 5: Error: Expected 'e', got "test" in value "SRID=4326;POINT(4.23test-005 -8e-003)"
+     */
+    public function testParsingWrongPointScientificValueWithSrid()
+    {
+        $value    = 'SRID=4326;POINT(4.23test-005 -8e-003)';
+        $parser   = new StringParser($value);
+
+        $parser->parse();
+    }
 
 
     /**


### PR DESCRIPTION
The following format (int/float)e(integer) was causing issue before.
It's fixed. Now the following point:
- SRID=4326;POINT(4.23e-005 -8e-003)
will pass.
- SRID=4326;POINT(4.23test-005 -8e-003)
will fail