### PR TITLE
Replace Point regex with parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
     "license": "MIT",
     "require": {
-        "doctrine/orm": ">=2.3"
+        "doctrine/orm": ">=2.3",
+        "creof/geo-parser": ">=1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "<5.0",

--- a/lib/CrEOF/Spatial/PHP/Types/AbstractPoint.php
+++ b/lib/CrEOF/Spatial/PHP/Types/AbstractPoint.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2012 Derek J. Lambert
+ * Copyright (C) 2015 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/lib/CrEOF/Spatial/PHP/Types/Geography/Point.php
+++ b/lib/CrEOF/Spatial/PHP/Types/Geography/Point.php
@@ -23,6 +23,9 @@
 
 namespace CrEOF\Spatial\PHP\Types\Geography;
 
+use CrEOF\Geo\Exception\RangeException;
+use CrEOF\Geo\Exception\UnexpectedValueException;
+use CrEOF\Geo\Parser;
 use CrEOF\Spatial\Exception\InvalidValueException;
 use CrEOF\Spatial\PHP\Types\AbstractPoint;
 
@@ -35,11 +38,22 @@ use CrEOF\Spatial\PHP\Types\AbstractPoint;
 class Point extends AbstractPoint implements GeographyInterface
 {
     /**
-     * {@inheritdoc}
+     * @param mixed $x
+     *
+     * @return self
+     * @throws InvalidValueException
      */
     public function setX($x)
     {
-        $x = $this->toFloat($x);
+        $parser = new Parser($x);
+
+        try {
+            $x = (float) $parser->parse();
+        } catch (RangeException $e) {
+            throw new InvalidValueException($e->getMessage(), $e->getCode(), $e->getPrevious());
+        } catch (UnexpectedValueException $e) {
+            throw new InvalidValueException($e->getMessage(), $e->getCode(), $e->getPrevious());
+        }
 
         if ($x < -180 || $x > 180) {
             throw InvalidValueException::invalidLongitude($x);
@@ -51,11 +65,22 @@ class Point extends AbstractPoint implements GeographyInterface
     }
 
     /**
-     * {@inheritdoc}
+     * @param mixed $y
+     *
+     * @return self
+     * @throws InvalidValueException
      */
     public function setY($y)
     {
-        $y = $this->toFloat($y);
+        $parser = new Parser($y);
+
+        try {
+            $y = (float) $parser->parse();
+        } catch (RangeException $e) {
+            throw new InvalidValueException($e->getMessage(), $e->getCode(), $e->getPrevious());
+        } catch (UnexpectedValueException $e) {
+            throw new InvalidValueException($e->getMessage(), $e->getCode(), $e->getPrevious());
+        }
 
         if ($y < -90 || $y > 90) {
             throw InvalidValueException::invalidLatitude($y);

--- a/lib/CrEOF/Spatial/PHP/Types/Geography/Point.php
+++ b/lib/CrEOF/Spatial/PHP/Types/Geography/Point.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2012 Derek J. Lambert
+ * Copyright (C) 2015 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tests/CrEOF/Spatial/Tests/PHP/Types/Geography/PointTest.php
+++ b/tests/CrEOF/Spatial/Tests/PHP/Types/Geography/PointTest.php
@@ -85,7 +85,7 @@ class PointTest extends \PHPUnit_Framework_TestCase
      * Test bad string parameters - invalid latitude direction
      *
      * @expectedException        \CrEOF\Spatial\Exception\InvalidValueException
-     * @expectedExceptionMessage 84:26:46Q is not a valid coordinate value.
+     * @expectedExceptionMessage [Syntax Error] line 0, col 8: Error: Expected CrEOF\Geo\Lexer::T_INTEGER or CrEOF\Geo\Lexer::T_FLOAT, got "Q" in value "84:26:46Q"
      */
     public function testBadLatitudeDirection()
     {
@@ -96,7 +96,7 @@ class PointTest extends \PHPUnit_Framework_TestCase
      * Test bad string parameters - latitude degrees greater that 90
      *
      * @expectedException        \CrEOF\Spatial\Exception\InvalidValueException
-     * @expectedExceptionMessage 92:26:46N is not a valid coordinate value.
+     * @expectedExceptionMessage [Range Error] Error: Degrees out of range -90 to 90 in value "92:26:46N"
      */
     public function testBadLatitudeDegrees()
     {
@@ -107,7 +107,7 @@ class PointTest extends \PHPUnit_Framework_TestCase
      * Test bad string parameters - latitude minutes greater than 59
      *
      * @expectedException        \CrEOF\Spatial\Exception\InvalidValueException
-     * @expectedExceptionMessage 84:64:46N is not a valid coordinate value.
+     * @expectedExceptionMessage [Range Error] Error: Minutes greater than 60 in value "84:64:46N"
      */
     public function testBadLatitudeMinutes()
     {
@@ -118,7 +118,7 @@ class PointTest extends \PHPUnit_Framework_TestCase
      * Test bad string parameters - latitude seconds greater than 59
      *
      * @expectedException        \CrEOF\Spatial\Exception\InvalidValueException
-     * @expectedExceptionMessage 84:23:75N is not a valid coordinate value.
+     * @expectedExceptionMessage [Range Error] Error: Seconds greater than 60 in value "84:23:75N"
      */
     public function testBadLatitudeSeconds()
     {
@@ -129,7 +129,7 @@ class PointTest extends \PHPUnit_Framework_TestCase
      * Test bad string parameters - invalid longitude direction
      *
      * @expectedException        \CrEOF\Spatial\Exception\InvalidValueException
-     * @expectedExceptionMessage 100:56:55P is not a valid coordinate value.
+     * @expectedExceptionMessage [Syntax Error] line 0, col 9: Error: Expected CrEOF\Geo\Lexer::T_INTEGER or CrEOF\Geo\Lexer::T_FLOAT, got "P" in value "100:56:55P"
      */
     public function testBadLongitudeDirection()
     {
@@ -140,7 +140,7 @@ class PointTest extends \PHPUnit_Framework_TestCase
      * Test bad string parameters - longitude degrees greater than 180
      *
      * @expectedException        \CrEOF\Spatial\Exception\InvalidValueException
-     * @expectedExceptionMessage 190:56:55W is not a valid coordinate value.
+     * @expectedExceptionMessage [Range Error] Error: Degrees out of range -180 to 180 in value "190:56:55W"
      */
     public function testBadLongitudeDegrees()
     {
@@ -151,7 +151,7 @@ class PointTest extends \PHPUnit_Framework_TestCase
      * Test bad string parameters - longitude minutes greater than 59
      *
      * @expectedException        \CrEOF\Spatial\Exception\InvalidValueException
-     * @expectedExceptionMessage 108:62:55W is not a valid coordinate value.
+     * @expectedExceptionMessage [Range Error] Error: Minutes greater than 60 in value "108:62:55W"
      */
     public function testBadLongitudeMinutes()
     {
@@ -162,7 +162,7 @@ class PointTest extends \PHPUnit_Framework_TestCase
      * Test bad string parameters - longitude seconds greater than 59
      *
      * @expectedException        \CrEOF\Spatial\Exception\InvalidValueException
-     * @expectedExceptionMessage 108:53:94W is not a valid coordinate value.
+     * @expectedExceptionMessage [Range Error] Error: Seconds greater than 60 in value "108:53:94W"
      */
     public function testBadLongitudeSeconds()
     {

--- a/tests/CrEOF/Spatial/Tests/PHP/Types/Geography/PointTest.php
+++ b/tests/CrEOF/Spatial/Tests/PHP/Types/Geography/PointTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2012 Derek J. Lambert
+ * Copyright (C) 2015 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tests/CrEOF/Spatial/Tests/PHP/Types/Geography/PointTest.php
+++ b/tests/CrEOF/Spatial/Tests/PHP/Types/Geography/PointTest.php
@@ -75,10 +75,10 @@ class PointTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(40.446261944444, $point7->getLatitude());
         $this->assertEquals(-79.948842222222, $point7->getLongitude());
 
-        $point7 = new Point('112:4:0W', '33:27:0N');
+        $point8 = new Point('112:4:0W', '33:27:0N');
 
-        $this->assertEquals(33.45, $point7->getLatitude());
-        $this->assertEquals(-112.06666666667, $point7->getLongitude());
+        $this->assertEquals(33.45, $point8->getLatitude());
+        $this->assertEquals(-112.06666666667, $point8->getLongitude());
     }
 
     /**

--- a/tests/CrEOF/Spatial/Tests/PHP/Types/Geometry/PointTest.php
+++ b/tests/CrEOF/Spatial/Tests/PHP/Types/Geometry/PointTest.php
@@ -85,7 +85,7 @@ class PointTest extends \PHPUnit_Framework_TestCase
      * Test bad string parameters - invalid latitude direction
      *
      * @expectedException        \CrEOF\Spatial\Exception\InvalidValueException
-     * @expectedExceptionMessage 84:26:46Q is not a valid coordinate value.
+     * @expectedExceptionMessage [Syntax Error] line 0, col 8: Error: Expected CrEOF\Geo\Lexer::T_INTEGER or CrEOF\Geo\Lexer::T_FLOAT, got "Q" in value "84:26:46Q"
      */
     public function testBadLatitudeDirection()
     {
@@ -96,7 +96,7 @@ class PointTest extends \PHPUnit_Framework_TestCase
      * Test bad string parameters - latitude degrees greater that 90
      *
      * @expectedException        \CrEOF\Spatial\Exception\InvalidValueException
-     * @expectedExceptionMessage 92:26:46N is not a valid coordinate value.
+     * @expectedExceptionMessage [Range Error] Error: Degrees out of range -90 to 90 in value "92:26:46N"
      */
     public function testBadLatitudeDegrees()
     {
@@ -107,7 +107,7 @@ class PointTest extends \PHPUnit_Framework_TestCase
      * Test bad string parameters - latitude minutes greater than 59
      *
      * @expectedException        \CrEOF\Spatial\Exception\InvalidValueException
-     * @expectedExceptionMessage 84:64:46N is not a valid coordinate value.
+     * @expectedExceptionMessage [Range Error] Error: Minutes greater than 60 in value "84:64:46N"
      */
     public function testBadLatitudeMinutes()
     {
@@ -118,7 +118,7 @@ class PointTest extends \PHPUnit_Framework_TestCase
      * Test bad string parameters - latitude seconds greater than 59
      *
      * @expectedException        \CrEOF\Spatial\Exception\InvalidValueException
-     * @expectedExceptionMessage 84:23:75N is not a valid coordinate value.
+     * @expectedExceptionMessage [Range Error] Error: Seconds greater than 60 in value "84:23:75N"
      */
     public function testBadLatitudeSeconds()
     {
@@ -129,7 +129,7 @@ class PointTest extends \PHPUnit_Framework_TestCase
      * Test bad string parameters - invalid longitude direction
      *
      * @expectedException        \CrEOF\Spatial\Exception\InvalidValueException
-     * @expectedExceptionMessage 100:56:55P is not a valid coordinate value.
+     * @expectedExceptionMessage [Syntax Error] line 0, col 9: Error: Expected CrEOF\Geo\Lexer::T_INTEGER or CrEOF\Geo\Lexer::T_FLOAT, got "P" in value "100:56:55P"
      */
     public function testBadLongitudeDirection()
     {
@@ -140,7 +140,7 @@ class PointTest extends \PHPUnit_Framework_TestCase
      * Test bad string parameters - longitude degrees greater than 180
      *
      * @expectedException        \CrEOF\Spatial\Exception\InvalidValueException
-     * @expectedExceptionMessage 190:56:55W is not a valid coordinate value.
+     * @expectedExceptionMessage [Range Error] Error: Degrees out of range -180 to 180 in value "190:56:55W"
      */
     public function testBadLongitudeDegrees()
     {
@@ -151,7 +151,7 @@ class PointTest extends \PHPUnit_Framework_TestCase
      * Test bad string parameters - longitude minutes greater than 59
      *
      * @expectedException        \CrEOF\Spatial\Exception\InvalidValueException
-     * @expectedExceptionMessage 108:62:55W is not a valid coordinate value.
+     * @expectedExceptionMessage [Range Error] Error: Minutes greater than 60 in value "108:62:55W"
      */
     public function testBadLongitudeMinutes()
     {
@@ -162,7 +162,7 @@ class PointTest extends \PHPUnit_Framework_TestCase
      * Test bad string parameters - longitude seconds greater than 59
      *
      * @expectedException        \CrEOF\Spatial\Exception\InvalidValueException
-     * @expectedExceptionMessage 108:53:94W is not a valid coordinate value.
+     * @expectedExceptionMessage [Range Error] Error: Seconds greater than 60 in value "108:53:94W"
      */
     public function testBadLongitudeSeconds()
     {

--- a/tests/CrEOF/Spatial/Tests/PHP/Types/Geometry/PointTest.php
+++ b/tests/CrEOF/Spatial/Tests/PHP/Types/Geometry/PointTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2012 Derek J. Lambert
+ * Copyright (C) 2015 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/tests/CrEOF/Spatial/Tests/PHP/Types/Geometry/PointTest.php
+++ b/tests/CrEOF/Spatial/Tests/PHP/Types/Geometry/PointTest.php
@@ -75,10 +75,10 @@ class PointTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(40.446261944444, $point7->getLatitude());
         $this->assertEquals(-79.948842222222, $point7->getLongitude());
 
-        $point7 = new Point('112:4:0W', '33:27:0N');
+        $point8 = new Point('112:4:0W', '33:27:0N');
 
-        $this->assertEquals(33.45, $point7->getLatitude());
-        $this->assertEquals(-112.06666666667, $point7->getLongitude());
+        $this->assertEquals(33.45, $point8->getLatitude());
+        $this->assertEquals(-112.06666666667, $point8->getLongitude());
     }
 
     /**

--- a/tests/travis/composer.orm2.3.json
+++ b/tests/travis/composer.orm2.3.json
@@ -11,7 +11,8 @@
     ],
     "license": "MIT",
     "require": {
-        "doctrine/orm": "<2.4"
+        "doctrine/orm": "<2.4",
+        "creof/geo-parser": ">=1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "<5.0",

--- a/tests/travis/composer.orm2.4.json
+++ b/tests/travis/composer.orm2.4.json
@@ -11,7 +11,8 @@
     ],
     "license": "MIT",
     "require": {
-        "doctrine/orm": "<2.5"
+        "doctrine/orm": "<2.5",
+        "creof/geo-parser": ">=1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "<5.0",

--- a/tests/travis/composer.orm2.5.json
+++ b/tests/travis/composer.orm2.5.json
@@ -11,7 +11,8 @@
     ],
     "license": "MIT",
     "require": {
-        "doctrine/orm": "<2.6"
+        "doctrine/orm": "<2.6",
+        "creof/geo-parser": ">=1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "<5.0",


### PR DESCRIPTION
This replaces the massive ugly regex in AbstractPoint with the parser from creof/geo-parser.

Added try/catch blocks in setters to throw local exceptions. Updated the expected exception messages in the tests to the much more descriptive ones now returned.