### PR TITLE
Rename AbstractGeometryType to AbstractSpatialType, refactor abstract methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - Added support for PostgreSql ST_MakeEnvelope function.
 ### Changed
+- Added implementation of getTypeFamily() and getSQLType() to AbstractGeometryType.
+- Rename AbstractGeometryType class to AbstractSpatialType.
+- Simplify logic in isClosed() method of AbstractLineString.
+- Updated copyright year in LICENSE.
 ### Removed
+- Unused imports from a number of classes.
 
 ## [1.1] - 2015-12-20
 ### Added
@@ -77,5 +82,5 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - StringLexer and StringParser now correctly handle values with exponent/scientific notation.
 
 ### Removed
-- AbstractDualGeometryDQLFunction, AbstractDualGeometryOptionalParameterDQLFunction, AbstractGeometryDQLFunction, AbstractSingleGeometryDQLFunction, AbstractTripleGeometryDQLFunction, and AbstractVariableGeometryDQLFunction classes. 
+- AbstractDualGeometryDQLFunction, AbstractDualGeometryOptionalParameterDQLFunction, AbstractGeometryDQLFunction, AbstractSingleGeometryDQLFunction, AbstractTripleGeometryDQLFunction, and AbstractVariableGeometryDQLFunction classes.
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2012, 2013, 2014 Derek J. Lambert
+Copyright (C) 2012-2015 Derek J. Lambert
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/lib/CrEOF/Spatial/DBAL/Platform/AbstractPlatform.php
+++ b/lib/CrEOF/Spatial/DBAL/Platform/AbstractPlatform.php
@@ -25,7 +25,7 @@ namespace CrEOF\Spatial\DBAL\Platform;
 
 use CrEOF\Geo\WKT\Parser as StringParser;
 use CrEOF\Geo\WKB\Parser as BinaryParser;
-use CrEOF\Spatial\DBAL\Types\AbstractGeometryType;
+use CrEOF\Spatial\DBAL\Types\AbstractSpatialType;
 use CrEOF\Spatial\DBAL\Types\GeographyType;
 use CrEOF\Spatial\Exception\InvalidValueException;
 use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
@@ -39,12 +39,12 @@ use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
 abstract class AbstractPlatform implements PlatformInterface
 {
     /**
-     * @param AbstractGeometryType $type
-     * @param string $sqlExpr
+     * @param AbstractSpatialType $type
+     * @param string              $sqlExpr
      *
      * @return GeometryInterface
      */
-    public function convertStringToPHPValue(AbstractGeometryType $type, $sqlExpr)
+    public function convertStringToPHPValue(AbstractSpatialType $type, $sqlExpr)
     {
         $parser = new StringParser($sqlExpr);
 
@@ -52,12 +52,12 @@ abstract class AbstractPlatform implements PlatformInterface
     }
 
     /**
-     * @param AbstractGeometryType $type
-     * @param string               $sqlExpr
+     * @param AbstractSpatialType $type
+     * @param string              $sqlExpr
      *
      * @return GeometryInterface
      */
-    public function convertBinaryToPHPValue(AbstractGeometryType $type, $sqlExpr)
+    public function convertBinaryToPHPValue(AbstractSpatialType $type, $sqlExpr)
     {
         $parser = new BinaryParser($sqlExpr);
 
@@ -65,12 +65,12 @@ abstract class AbstractPlatform implements PlatformInterface
     }
 
     /**
-     * @param AbstractGeometryType $type
-     * @param GeometryInterface    $value
+     * @param AbstractSpatialType $type
+     * @param GeometryInterface   $value
      *
      * @return string
      */
-    public function convertToDatabaseValue(AbstractGeometryType $type, GeometryInterface $value)
+    public function convertToDatabaseValue(AbstractSpatialType $type, GeometryInterface $value)
     {
         return sprintf('%s(%s)', strtoupper($value->getType()), $value);
     }
@@ -78,11 +78,11 @@ abstract class AbstractPlatform implements PlatformInterface
     /**
      * Get an array of database types that map to this Doctrine type.
      *
-     * @param AbstractGeometryType $type
+     * @param AbstractSpatialType $type
      *
      * @return string[]
      */
-    public function getMappedDatabaseTypes(AbstractGeometryType $type)
+    public function getMappedDatabaseTypes(AbstractSpatialType $type)
     {
         $sqlType = strtolower($type->getSQLType());
 
@@ -96,13 +96,13 @@ abstract class AbstractPlatform implements PlatformInterface
     /**
      * Create spatial object from parsed value
      *
-     * @param AbstractGeometryType $type
-     * @param array                $value
+     * @param AbstractSpatialType $type
+     * @param array               $value
      *
      * @return GeometryInterface
      * @throws \CrEOF\Spatial\Exception\InvalidValueException
      */
-    private function newObjectFromValue(AbstractGeometryType $type, $value)
+    private function newObjectFromValue(AbstractSpatialType $type, $value)
     {
         $typeFamily = $type->getTypeFamily();
         $typeName   = strtoupper($value['type']);

--- a/lib/CrEOF/Spatial/DBAL/Platform/MySql.php
+++ b/lib/CrEOF/Spatial/DBAL/Platform/MySql.php
@@ -23,7 +23,7 @@
 
 namespace CrEOF\Spatial\DBAL\Platform;
 
-use CrEOF\Spatial\DBAL\Types\AbstractGeometryType;
+use CrEOF\Spatial\DBAL\Types\AbstractSpatialType;
 use CrEOF\Spatial\PHP\Types\Geography\GeographyInterface;
 
 /**
@@ -51,23 +51,23 @@ class MySql extends AbstractPlatform
     }
 
     /**
-     * @param AbstractGeometryType $type
-     * @param string               $sqlExpr
+     * @param AbstractSpatialType $type
+     * @param string              $sqlExpr
      *
      * @return string
      */
-    public function convertToPHPValueSQL(AbstractGeometryType $type, $sqlExpr)
+    public function convertToPHPValueSQL(AbstractSpatialType $type, $sqlExpr)
     {
         return sprintf('AsBinary(%s)', $sqlExpr);
     }
 
     /**
-     * @param AbstractGeometryType $type
-     * @param string               $sqlExpr
+     * @param AbstractSpatialType $type
+     * @param string              $sqlExpr
      *
      * @return string
      */
-    public function convertToDatabaseValueSQL(AbstractGeometryType $type, $sqlExpr)
+    public function convertToDatabaseValueSQL(AbstractSpatialType $type, $sqlExpr)
     {
         return sprintf('GeomFromText(%s)', $sqlExpr);
     }

--- a/lib/CrEOF/Spatial/DBAL/Platform/PlatformInterface.php
+++ b/lib/CrEOF/Spatial/DBAL/Platform/PlatformInterface.php
@@ -23,7 +23,7 @@
 
 namespace CrEOF\Spatial\DBAL\Platform;
 
-use CrEOF\Spatial\DBAL\Types\AbstractGeometryType;
+use CrEOF\Spatial\DBAL\Types\AbstractSpatialType;
 use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
 
 /**
@@ -35,44 +35,44 @@ use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
 interface PlatformInterface
 {
     /**
-     * @param AbstractGeometryType $type
-     * @param string               $sqlExpr
+     * @param AbstractSpatialType $type
+     * @param string              $sqlExpr
      *
      * @return GeometryInterface
      */
-    public function convertBinaryToPHPValue(AbstractGeometryType $type, $sqlExpr);
+    public function convertBinaryToPHPValue(AbstractSpatialType $type, $sqlExpr);
 
     /**
-     * @param AbstractGeometryType $type
-     * @param string               $sqlExpr
+     * @param AbstractSpatialType $type
+     * @param string              $sqlExpr
      *
      * @return GeometryInterface
      */
-    public function convertStringToPHPValue(AbstractGeometryType $type, $sqlExpr);
+    public function convertStringToPHPValue(AbstractSpatialType $type, $sqlExpr);
 
     /**
-     * @param AbstractGeometryType $type
-     * @param GeometryInterface    $value
+     * @param AbstractSpatialType $type
+     * @param GeometryInterface   $value
      *
      * @return string
      */
-    public function convertToDatabaseValue(AbstractGeometryType $type, GeometryInterface $value);
+    public function convertToDatabaseValue(AbstractSpatialType $type, GeometryInterface $value);
 
     /**
-     * @param AbstractGeometryType $type
-     * @param string               $sqlExpr
+     * @param AbstractSpatialType $type
+     * @param string              $sqlExpr
      *
      * @return string
      */
-    public function convertToDatabaseValueSQL(AbstractGeometryType $type, $sqlExpr);
+    public function convertToDatabaseValueSQL(AbstractSpatialType $type, $sqlExpr);
 
     /**
-     * @param AbstractGeometryType $type
-     * @param string               $sqlExpr
+     * @param AbstractSpatialType $type
+     * @param string              $sqlExpr
      *
      * @return string
      */
-    public function convertToPHPValueSQL(AbstractGeometryType $type, $sqlExpr);
+    public function convertToPHPValueSQL(AbstractSpatialType $type, $sqlExpr);
 
     /**
      * Gets the SQL declaration snippet for a field of this type.
@@ -84,9 +84,9 @@ interface PlatformInterface
     public function getSQLDeclaration(array $fieldDeclaration);
 
     /**
-     * @param AbstractGeometryType $type
+     * @param AbstractSpatialType $type
      *
      * @return string[]
      */
-    public function getMappedDatabaseTypes(AbstractGeometryType $type);
+    public function getMappedDatabaseTypes(AbstractSpatialType $type);
 }

--- a/lib/CrEOF/Spatial/DBAL/Platform/PostgreSql.php
+++ b/lib/CrEOF/Spatial/DBAL/Platform/PostgreSql.php
@@ -23,7 +23,7 @@
 
 namespace CrEOF\Spatial\DBAL\Platform;
 
-use CrEOF\Spatial\DBAL\Types\AbstractGeometryType;
+use CrEOF\Spatial\DBAL\Types\AbstractSpatialType;
 use CrEOF\Spatial\DBAL\Types\GeographyType;
 use CrEOF\Spatial\Exception\InvalidValueException;
 use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
@@ -62,12 +62,12 @@ class PostgreSql extends AbstractPlatform
     }
 
     /**
-     * @param AbstractGeometryType $type
-     * @param string               $sqlExpr
+     * @param AbstractSpatialType $type
+     * @param string              $sqlExpr
      *
      * @return string
      */
-    public function convertToPHPValueSQL(AbstractGeometryType $type, $sqlExpr)
+    public function convertToPHPValueSQL(AbstractSpatialType $type, $sqlExpr)
     {
         if ($type instanceof GeographyType) {
             return sprintf('ST_AsEWKT(%s)', $sqlExpr);
@@ -77,12 +77,12 @@ class PostgreSql extends AbstractPlatform
     }
 
     /**
-     * @param AbstractGeometryType $type
-     * @param string               $sqlExpr
+     * @param AbstractSpatialType $type
+     * @param string              $sqlExpr
      *
      * @return string
      */
-    public function convertToDatabaseValueSQL(AbstractGeometryType $type, $sqlExpr)
+    public function convertToDatabaseValueSQL(AbstractSpatialType $type, $sqlExpr)
     {
         if ($type instanceof GeographyType) {
             return sprintf('ST_GeographyFromText(%s)', $sqlExpr);
@@ -92,13 +92,13 @@ class PostgreSql extends AbstractPlatform
     }
 
     /**
-     * @param AbstractGeometryType $type
-     * @param string               $sqlExpr
+     * @param AbstractSpatialType $type
+     * @param string              $sqlExpr
      *
      * @return GeometryInterface
      * @throws InvalidValueException
      */
-    public function convertBinaryToPHPValue(AbstractGeometryType $type, $sqlExpr)
+    public function convertBinaryToPHPValue(AbstractSpatialType $type, $sqlExpr)
     {
         if (! is_resource($sqlExpr)) {
             throw new InvalidValueException(sprintf('Invalid resource value "%s"', $sqlExpr));
@@ -110,12 +110,12 @@ class PostgreSql extends AbstractPlatform
     }
 
     /**
-     * @param AbstractGeometryType $type
-     * @param GeometryInterface    $value
+     * @param AbstractSpatialType $type
+     * @param GeometryInterface   $value
      *
      * @return string
      */
-    public function convertToDatabaseValue(AbstractGeometryType $type, GeometryInterface $value)
+    public function convertToDatabaseValue(AbstractSpatialType $type, GeometryInterface $value)
     {
         $sridSQL = null;
 

--- a/lib/CrEOF/Spatial/DBAL/Types/AbstractGeometryType.php
+++ b/lib/CrEOF/Spatial/DBAL/Types/AbstractGeometryType.php
@@ -149,7 +149,7 @@ abstract class AbstractGeometryType extends Type
      */
     public function getName()
     {
-        return array_search(get_class($this), $this->getTypesMap());
+        return array_search(get_class($this), self::getTypesMap(), true);
     }
 
     /**

--- a/lib/CrEOF/Spatial/DBAL/Types/AbstractGeometryType.php
+++ b/lib/CrEOF/Spatial/DBAL/Types/AbstractGeometryType.php
@@ -26,6 +26,7 @@ namespace CrEOF\Spatial\DBAL\Types;
 use CrEOF\Spatial\Exception\InvalidValueException;
 use CrEOF\Spatial\Exception\UnsupportedPlatformException;
 use CrEOF\Spatial\DBAL\Platform\PlatformInterface;
+use CrEOF\Spatial\PHP\Types\Geography\GeographyInterface;
 use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
 use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\Type;
@@ -44,14 +45,24 @@ abstract class AbstractGeometryType extends Type
     /**
      * @return string
      */
-    abstract public function getTypeFamily();
+    public function getTypeFamily()
+    {
+        return $this instanceof GeographyType ? GeographyInterface::GEOGRAPHY : GeometryInterface::GEOMETRY;
+    }
 
     /**
      * Gets the SQL name of this type.
      *
      * @return string
      */
-    abstract public function getSQLType();
+    public function getSQLType()
+    {
+        $class = get_class($this);
+        $start = strrpos($class, '\\') + 1;
+        $len   = strlen($class) - $start - 4;
+
+        return substr($class, strrpos($class, '\\') + 1, $len);
+    }
 
     /**
      * @return bool

--- a/lib/CrEOF/Spatial/DBAL/Types/AbstractSpatialType.php
+++ b/lib/CrEOF/Spatial/DBAL/Types/AbstractSpatialType.php
@@ -37,7 +37,7 @@ use Doctrine\DBAL\Types\Type;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  */
-abstract class AbstractGeometryType extends Type
+abstract class AbstractSpatialType extends Type
 {
     const PLATFORM_MYSQL      = 'MySql';
     const PLATFORM_POSTGRESQL = 'PostgreSql';

--- a/lib/CrEOF/Spatial/DBAL/Types/Geography/LineStringType.php
+++ b/lib/CrEOF/Spatial/DBAL/Types/Geography/LineStringType.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2012 Derek J. Lambert
+ * Copyright (C) 2015 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,6 @@
 namespace CrEOF\Spatial\DBAL\Types\Geography;
 
 use CrEOF\Spatial\DBAL\Types\GeographyType;
-use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
 
 /**
  * Doctrine LINESTRING type
@@ -34,11 +33,5 @@ use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
  */
 class LineStringType extends GeographyType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getSQLType()
-    {
-        return GeometryInterface::LINESTRING;
-    }
+
 }

--- a/lib/CrEOF/Spatial/DBAL/Types/Geography/PointType.php
+++ b/lib/CrEOF/Spatial/DBAL/Types/Geography/PointType.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2012 Derek J. Lambert
+ * Copyright (C) 2015 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,6 @@
 namespace CrEOF\Spatial\DBAL\Types\Geography;
 
 use CrEOF\Spatial\DBAL\Types\GeographyType;
-use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
 
 /**
  * Doctrine POINT type
@@ -34,11 +33,5 @@ use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
  */
 class PointType extends GeographyType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getSQLType()
-    {
-        return GeometryInterface::POINT;
-    }
+
 }

--- a/lib/CrEOF/Spatial/DBAL/Types/Geography/PolygonType.php
+++ b/lib/CrEOF/Spatial/DBAL/Types/Geography/PolygonType.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2012 Derek J. Lambert
+ * Copyright (C) 2015 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,6 @@
 namespace CrEOF\Spatial\DBAL\Types\Geography;
 
 use CrEOF\Spatial\DBAL\Types\GeographyType;
-use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
 
 /**
  * Doctrine POLYGON type
@@ -34,11 +33,5 @@ use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
  */
 class PolygonType extends GeographyType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getSQLType()
-    {
-        return GeometryInterface::POLYGON;
-    }
+
 }

--- a/lib/CrEOF/Spatial/DBAL/Types/GeographyType.php
+++ b/lib/CrEOF/Spatial/DBAL/Types/GeographyType.php
@@ -29,7 +29,7 @@ namespace CrEOF\Spatial\DBAL\Types;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  */
-class GeographyType extends AbstractGeometryType
+class GeographyType extends AbstractSpatialType
 {
 
 }

--- a/lib/CrEOF/Spatial/DBAL/Types/GeographyType.php
+++ b/lib/CrEOF/Spatial/DBAL/Types/GeographyType.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2012 Derek J. Lambert
+ * Copyright (C) 2015 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +23,6 @@
 
 namespace CrEOF\Spatial\DBAL\Types;
 
-use CrEOF\Spatial\PHP\Types\Geography\GeographyInterface;
-
 /**
  * Doctrine GEOGRAPHY type
  *
@@ -33,19 +31,5 @@ use CrEOF\Spatial\PHP\Types\Geography\GeographyInterface;
  */
 class GeographyType extends AbstractGeometryType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getSQLType()
-    {
-        return GeographyInterface::GEOGRAPHY;
-    }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getTypeFamily()
-    {
-        return GeographyInterface::GEOGRAPHY;
-    }
 }

--- a/lib/CrEOF/Spatial/DBAL/Types/Geometry/LineStringType.php
+++ b/lib/CrEOF/Spatial/DBAL/Types/Geometry/LineStringType.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2012 Derek J. Lambert
+ * Copyright (C) 2015 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,6 @@
 namespace CrEOF\Spatial\DBAL\Types\Geometry;
 
 use CrEOF\Spatial\DBAL\Types\GeometryType;
-use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
 
 /**
  * Doctrine LINESTRING type
@@ -34,11 +33,5 @@ use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
  */
 class LineStringType extends GeometryType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getSQLType()
-    {
-        return GeometryInterface::LINESTRING;
-    }
+
 }

--- a/lib/CrEOF/Spatial/DBAL/Types/Geometry/MultiPolygonType.php
+++ b/lib/CrEOF/Spatial/DBAL/Types/Geometry/MultiPolygonType.php
@@ -24,7 +24,6 @@
 namespace CrEOF\Spatial\DBAL\Types\Geometry;
 
 use CrEOF\Spatial\DBAL\Types\GeometryType;
-use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
 
 /**
  * Doctrine MULTIPOLYGON type
@@ -34,11 +33,5 @@ use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
  */
 class MultiPolygonType extends GeometryType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getSQLType()
-    {
-        return GeometryInterface::MULTIPOLYGON;
-    }
+
 }

--- a/lib/CrEOF/Spatial/DBAL/Types/Geometry/PointType.php
+++ b/lib/CrEOF/Spatial/DBAL/Types/Geometry/PointType.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2012 Derek J. Lambert
+ * Copyright (C) 2015 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,6 @@
 namespace CrEOF\Spatial\DBAL\Types\Geometry;
 
 use CrEOF\Spatial\DBAL\Types\GeometryType;
-use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
 
 /**
  * Doctrine POINT type
@@ -34,11 +33,5 @@ use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
  */
 class PointType extends GeometryType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getSQLType()
-    {
-        return GeometryInterface::POINT;
-    }
+
 }

--- a/lib/CrEOF/Spatial/DBAL/Types/Geometry/PolygonType.php
+++ b/lib/CrEOF/Spatial/DBAL/Types/Geometry/PolygonType.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2012 Derek J. Lambert
+ * Copyright (C) 2015 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,6 @@
 namespace CrEOF\Spatial\DBAL\Types\Geometry;
 
 use CrEOF\Spatial\DBAL\Types\GeometryType;
-use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
 
 /**
  * Doctrine POLYGON type
@@ -34,11 +33,5 @@ use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
  */
 class PolygonType extends GeometryType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getSQLType()
-    {
-        return GeometryInterface::POLYGON;
-    }
+
 }

--- a/lib/CrEOF/Spatial/DBAL/Types/GeometryType.php
+++ b/lib/CrEOF/Spatial/DBAL/Types/GeometryType.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2012 Derek J. Lambert
+ * Copyright (C) 2015 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +23,6 @@
 
 namespace CrEOF\Spatial\DBAL\Types;
 
-use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
-
 /**
  * Doctrine GEOMETRY type
  *
@@ -33,19 +31,5 @@ use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
  */
 class GeometryType extends AbstractGeometryType
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getSQLType()
-    {
-        return GeometryInterface::GEOMETRY;
-    }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getTypeFamily()
-    {
-        return GeometryInterface::GEOMETRY;
-    }
 }

--- a/lib/CrEOF/Spatial/DBAL/Types/GeometryType.php
+++ b/lib/CrEOF/Spatial/DBAL/Types/GeometryType.php
@@ -29,7 +29,7 @@ namespace CrEOF\Spatial\DBAL\Types;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  */
-class GeometryType extends AbstractGeometryType
+class GeometryType extends AbstractSpatialType
 {
 
 }

--- a/lib/CrEOF/Spatial/PHP/Types/AbstractLineString.php
+++ b/lib/CrEOF/Spatial/PHP/Types/AbstractLineString.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2012 Derek J. Lambert
+ * Copyright (C) 2015 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,8 +22,6 @@
  */
 
 namespace CrEOF\Spatial\PHP\Types;
-
-use CrEOF\Spatial\Exception\InvalidValueException;
 
 /**
  * Abstract LineString object for LINESTRING spatial types

--- a/lib/CrEOF/Spatial/PHP/Types/AbstractLineString.php
+++ b/lib/CrEOF/Spatial/PHP/Types/AbstractLineString.php
@@ -44,10 +44,6 @@ abstract class AbstractLineString extends AbstractMultiPoint
      */
     public function isClosed()
     {
-        if ($this->points[0] === $this->points[count($this->points) - 1]) {
-            return true;
-        }
-
-        return false;
+        return $this->points[0] === $this->points[count($this->points) - 1];
     }
 }

--- a/lib/CrEOF/Spatial/PHP/Types/AbstractMultiLineString.php
+++ b/lib/CrEOF/Spatial/PHP/Types/AbstractMultiLineString.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2012 Derek J. Lambert
+ * Copyright (C) 2015 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,9 +22,6 @@
  */
 
 namespace CrEOF\Spatial\PHP\Types;
-
-use CrEOF\Spatial\Exception\InvalidValueException;
-use CrEOF\Spatial\PHP\Types\AbstractPoint;
 
 /**
  * Abstract MultiLineString object for MULTILINESTRING spatial types

--- a/lib/CrEOF/Spatial/PHP/Types/AbstractMultiPoint.php
+++ b/lib/CrEOF/Spatial/PHP/Types/AbstractMultiPoint.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2012 Derek J. Lambert
+ * Copyright (C) 2015 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,6 @@
 namespace CrEOF\Spatial\PHP\Types;
 
 use CrEOF\Spatial\Exception\InvalidValueException;
-use CrEOF\Spatial\PHP\Types\AbstractPoint;
 
 /**
  * Abstract MultiPoint object for MULTIPOINT spatial types

--- a/lib/CrEOF/Spatial/PHP/Types/AbstractMultiPolygon.php
+++ b/lib/CrEOF/Spatial/PHP/Types/AbstractMultiPolygon.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2012 Derek J. Lambert
+ * Copyright (C) 2015 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,9 +22,6 @@
  */
 
 namespace CrEOF\Spatial\PHP\Types;
-
-use CrEOF\Spatial\Exception\InvalidValueException;
-use CrEOF\Spatial\PHP\Types\AbstractPoint;
 
 /**
  * Abstract Polygon object for POLYGON spatial types

--- a/lib/CrEOF/Spatial/PHP/Types/AbstractPolygon.php
+++ b/lib/CrEOF/Spatial/PHP/Types/AbstractPolygon.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2012 Derek J. Lambert
+ * Copyright (C) 2015 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,9 +22,6 @@
  */
 
 namespace CrEOF\Spatial\PHP\Types;
-
-use CrEOF\Spatial\Exception\InvalidValueException;
-use CrEOF\Spatial\PHP\Types\AbstractPoint;
 
 /**
  * Abstract Polygon object for POLYGON spatial types

--- a/lib/CrEOF/Spatial/PHP/Types/Geography/LineString.php
+++ b/lib/CrEOF/Spatial/PHP/Types/Geography/LineString.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2012 Derek J. Lambert
+ * Copyright (C) 2015 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -24,7 +24,6 @@
 namespace CrEOF\Spatial\PHP\Types\Geography;
 
 use CrEOF\Spatial\PHP\Types\AbstractLineString;
-use CrEOF\Spatial\PHP\Types\AbstractPoint;
 
 /**
  * LineString object for LINESTRING geography type
@@ -34,4 +33,5 @@ use CrEOF\Spatial\PHP\Types\AbstractPoint;
  */
 class LineString extends AbstractLineString implements GeographyInterface
 {
+
 }

--- a/lib/CrEOF/Spatial/PHP/Types/Geography/Polygon.php
+++ b/lib/CrEOF/Spatial/PHP/Types/Geography/Polygon.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Copyright (C) 2012 Derek J. Lambert
+ * Copyright (C) 2015 Derek J. Lambert
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +23,6 @@
 
 namespace CrEOF\Spatial\PHP\Types\Geography;
 
-use CrEOF\Spatial\PHP\Types\AbstractLineString;
-use CrEOF\Spatial\PHP\Types\AbstractPoint;
 use CrEOF\Spatial\PHP\Types\AbstractPolygon;
 
 /**
@@ -35,4 +33,5 @@ use CrEOF\Spatial\PHP\Types\AbstractPolygon;
  */
 class Polygon extends AbstractPolygon implements GeographyInterface
 {
+
 }


### PR DESCRIPTION
Rename ```AbstractGeometryType``` class to ```AbstractSpatialType```. Implement ```getTypeFamily()``` and ```getSQLType()``` methods in abstract class. Cleanup some odds and ends.