### PR TITLE
Introducing a general support for native JSON serialization.

### DIFF
--- a/lib/CrEOF/Spatial/PHP/Types/AbstractGeometry.php
+++ b/lib/CrEOF/Spatial/PHP/Types/AbstractGeometry.php
@@ -32,7 +32,7 @@ use CrEOF\Spatial\PHP\Types\Geometry\GeometryInterface;
  * @author  Derek J. Lambert <dlambert@dereklambert.com>
  * @license http://dlambert.mit-license.org MIT
  */
-abstract class AbstractGeometry implements GeometryInterface
+abstract class AbstractGeometry implements GeometryInterface, \JsonSerializable
 {
     /**
      * @var int
@@ -63,6 +63,13 @@ abstract class AbstractGeometry implements GeometryInterface
         $json['type'] = $this->getType();
         $json['coordinates'] = $this->toArray();
         return json_encode($json);
+    }
+
+    /**
+     * @return array
+     */
+    public function jsonSerialize() {
+        return $this->toArray();
     }
 
     /**


### PR DESCRIPTION
Here's a rather simple patch that allows spatial data to be json-serialized through native PHP toolset. I am far from being 100% sure this patch covers all use cases, but it does mine (Symfony FOS rest bundle with a JSON content type).