### PR TITLE
Fix PHP 8.1 issue: Passing null to parameter #1 ($string) of type string is deprecated

### DIFF
--- a/lib/CrEOF/Spatial/DBAL/Platform/MySql.php
+++ b/lib/CrEOF/Spatial/DBAL/Platform/MySql.php
@@ -58,7 +58,7 @@ class MySql extends AbstractPlatform
      */
     public function convertToPHPValueSQL(AbstractSpatialType $type, $sqlExpr)
     {
-        return sprintf('AsBinary(%s)', $sqlExpr);
+        return sprintf('ST_AsBinary(%s)', $sqlExpr);
     }
 
     /**
@@ -69,6 +69,6 @@ class MySql extends AbstractPlatform
      */
     public function convertToDatabaseValueSQL(AbstractSpatialType $type, $sqlExpr)
     {
-        return sprintf('GeomFromText(%s)', $sqlExpr);
+        return sprintf('ST_GeomFromText(%s)', $sqlExpr);
     }
 }


### PR DESCRIPTION
**Fix PHP 8.1 issue:**
- 500 [GET] http://docker.for.mac.localhost:8081/locations/CA/Los_Angeles?with_shape=1: strlen(): Passing null to parameter 1 ($string) of type string is deprecated
- wkb-parser/lib/CrEOF/Geo/WKB/Parser.php [line:157]

https://php.watch/versions/8.1/internal-func-non-nullable-null-deprecation
