### PR TITLE
fix: support strong type for symfony 7 in AbstractSpatialDQLFunction class

### DIFF
--- a/lib/CrEOF/Spatial/ORM/Query/AST/Functions/AbstractSpatialDQLFunction.php
+++ b/lib/CrEOF/Spatial/ORM/Query/AST/Functions/AbstractSpatialDQLFunction.php
@@ -90,7 +90,7 @@ abstract class AbstractSpatialDQLFunction extends FunctionNode
      *
      * @return string
      */
-    public function getSql(SqlWalker $sqlWalker)
+    public function getSql(SqlWalker $sqlWalker): string
     {
         $this->validatePlatform($sqlWalker->getConnection()->getDatabasePlatform());
 


### PR DESCRIPTION
This allow strong type function based in Symfony 7

Fix the error:

`"Declaration of CrEOF\Spatial\ORM\Query\AST\Functions\AbstractSpatialDQLFunction::getSql(Doctrine\ORM\Query\SqlWalker $sqlWalker) must be compatible with Doctrine\ORM\Query\AST\Functions\FunctionNode::getSql(Doctrine\ORM\Query\SqlWalker $sqlWalker): string"`
